### PR TITLE
feat: add aiven-client package and expose in ops shell

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -31,4 +31,7 @@ final: prev: {
         --prefix XDG_DATA_DIRS : "${prev.gtk3}/share/gsettings-schemas/${prev.gtk3.name}"
     '';
   };
+
+  # Custom packages
+  aiven-client = prev.callPackage ../packages/aiven-client { };
 }

--- a/packages/aiven-client/default.nix
+++ b/packages/aiven-client/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "aiven-client";
+  version = "4.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aiven";
+    repo = "aiven-client";
+    rev = version;
+    hash = "sha256-0kGCbt08HOawwkHKxK76QfaDno+70iKs+zhTxOE+7hA=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = with python3Packages; [
+    requests
+    requests-toolbelt
+    certifi
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  doCheck = false;
+
+  meta = {
+    description = "Aiven command-line client";
+    homepage = "https://github.com/aiven/aiven-client";
+    license = lib.licenses.asl20;
+    mainProgram = "avn";
+  };
+}

--- a/shells/ops/default.nix
+++ b/shells/ops/default.nix
@@ -2,8 +2,11 @@
 pkgs.mkShell {
   packages = with pkgs; [
     actionlint
+    aiven-client
     ansible
     ansible-lint
+    openssl
+    postgresql
     restic
     tenv
     terraform-ls


### PR DESCRIPTION
## Summary

- Adds a custom Nix package for `aiven-client` v4.12.0 under `packages/aiven-client/`
- Registers it in `overlays/default.nix` via `callPackage`
- Adds `aiven-client`, `openssl`, and `postgresql` to the ops dev shell

> **Stacked on** `fix/freecad-overlay` — merge that first, then re-target this PR to `main`.

## Test plan

- [ ] `nix flake check`
- [ ] `nix build .#packages.x86_64-linux.aiven-client`
- [ ] `nix develop .#ops` → `avn --version`