### PR TITLE
feat: add claude-code from unstable and persist .claude.json

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -211,5 +211,6 @@
       ".claude"
       ".local/share/claude-code"
     ];
+    files = [ ".claude.json" ];
   };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -11,6 +11,7 @@ final: prev: {
     nushell
     calibre
     tidal-hifi
+    claude-code
     ;
 
   nushellPlugins.formats = unstable.nushellPlugins.formats;


### PR DESCRIPTION
## Summary

- Inherits `claude-code` from the unstable overlay so the latest version is always available
- Persists `.claude.json` across reboots (alongside the existing `.claude/` directory)

> **Stacked on** `feat/add-aiven-client` — merge that first, then re-target this PR to `main`.

## Test plan

- [ ] `nix flake check`
- [ ] `nh os switch` → `claude --version`
- [ ] Verify `.claude.json` survives a reboot