### PR TITLE
feat(shell): bash support, starship shell indicator, sessionPath

### DIFF
--- a/home/nushell/config.nu
+++ b/home/nushell/config.nu
@@ -1,7 +1,5 @@
 use std
 
-$env.path ++= ["~/.local/bin"]
-
 # List existing Zellij layouts (excluding homepage)
 def available-layouts [] {
   ls ~/.config/zellij/layouts/ | get name | path parse | get stem | where {|x| $x != "homepage" }

--- a/home/shell.nix
+++ b/home/shell.nix
@@ -196,11 +196,15 @@
         VISUAL = "hx";
         BWS_SERVER_URL = "https://vault.bitwarden.eu";
         CARAPACE_BRIDGES = "zsh,fish,bash,inshellisense";
+        XDG_DATA_DIRS = "$env.XDG_DATA_DIRS:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}";
       };
       shellAliases = {
         ll = "ls -la";
         k = "kubectl";
         cat = "bat";
+        b = "bash -c";
+        # Override the bash provided in dev shells
+        bash = "/run/current-system/sw/bin/bash";
       };
       settings = {
         show_banner = false;
@@ -243,6 +247,9 @@
             }
         )
       '';
+    };
+    bash = {
+      enable = true;
     };
 
     # Multiplexer
@@ -335,7 +342,7 @@
       enableTransience = true;
       settings = {
         # Based on the gruvbox-rainbow preset
-        format = "[](orange)$os$username[](bg:bright-yellow fg:orange)$directory[](fg:bright-yellow bg:bright-cyan)$git_branch$git_status[](fg:bright-cyan bg:bright-blue)$c$rust$golang$nodejs$php$java$kotlin$haskell$python[](fg:bright-blue bg:bright-black)$docker_context$conda[](fg:bright-black bg:base01)$time[ ](fg:base01)$line_break$character";
+        format = "[](orange)$os$username$shell[](bg:bright-yellow fg:orange)$directory[](fg:bright-yellow bg:bright-cyan)$git_branch$git_status[](fg:bright-cyan bg:bright-blue)$c$rust$golang$nodejs$php$java$kotlin$haskell$python[](fg:bright-blue bg:bright-black)$docker_context$conda[](fg:bright-black bg:base01)$time[ ](fg:base01)$line_break$character";
         os = {
           disabled = false;
           style = "bg:orange fg:bright-white";
@@ -367,6 +374,13 @@
           style_user = "bg:orange fg:bright-white";
           style_root = "bg:orange fg:bright-white";
           format = "[ $user ]($style)";
+        };
+        shell = {
+          disabled = false;
+          style = "bg:orange fg:bright-white";
+          format = "[$indicator]($style)";
+          bash_indicator = " ";
+          nu_indicator = "";
         };
         directory = {
           style = "fg:bright-white bg:bright-yellow";
@@ -499,6 +513,10 @@
       bitwarden-cli
     ];
 
+    sessionPath = [
+      "$HOME/.local/bin"
+    ];
+
     sessionVariables = {
       ZELLIJ_AUTO_ATTACH = "true";
       ZELLIJ_AUTO_EXIT = "true";
@@ -509,6 +527,7 @@
         ".config/nushell/history.txt"
         ".config/nushell/private.nu"
         ".config/Bitwarden CLI/data.json"
+        ".bash_history"
       ];
     };
   };


### PR DESCRIPTION
## Summary

- Enable `programs.bash` for use in dev shells and zellij
- Add zellij `pane` keybinding `b` → launch bash interactive login shell
- Add shell aliases: `b = "bash -c"`, `bash` overridden to system bash (avoids dev shell bash leaking)
- Add `XDG_DATA_DIRS` env var so GTK file dialogs work inside nushell sessions
- Add `\$shell` segment to starship prompt (shows  for nushell,  for bash)
- Move `~/.local/bin` to `home.sessionPath` (removes manual `\$env.path` line from `config.nu`)
- Persist `.bash_history` across reboots

## Test plan

- [ ] `nix flake check`
- [ ] `nh os switch`
- [ ] Open terminal: starship shows shell indicator
- [ ] In zellij pane mode, press `b` → bash shell opens
- [ ] `echo \$PATH` includes `~/.local/bin`