### PR TITLE
feat: add kubelogin to k8s tools

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -40,6 +40,7 @@
 
       # K8s tools
       kubectl
+      kubelogin
       fluxcd
       kind
       kubectx


### PR DESCRIPTION
## Summary

- Adds `kubelogin` to the home packages k8s tools group

## Test plan

- [ ] `nix flake check`
- [ ] `nh os switch` → `kubelogin --version`