### PR TITLE
feat(shell/python): add postgresql to python dev shell

### DIFF
--- a/shells/python/default.nix
+++ b/shells/python/default.nix
@@ -3,6 +3,7 @@ pkgs.mkShell {
   packages = with pkgs; [
     uv
     fnm
+    postgresql
     # Language Server Protocol
     python313Packages.python-lsp-server
     ruff


### PR DESCRIPTION
## Summary

- Adds `postgresql` to the python dev shell so `psql` and libpq are available

## Test plan

- [ ] `nix flake check`
- [ ] `nix develop .#python` → `psql --version`