### PR TITLE
feat(work): enable vscode on tuxedo host

### DIFF
--- a/home/work.nix
+++ b/home/work.nix
@@ -25,4 +25,10 @@
       ];
     };
   };
+
+  programs = {
+    vscode = {
+      enable = true;
+    };
+  };
 }


### PR DESCRIPTION
## Summary

- Enables `programs.vscode` in the work home-manager module (tuxedo host only)

## Test plan

- [ ] `nix flake check`
- [ ] `nh os switch` on tuxedo → VS Code launches