### PR TITLE
feat(dendritic): convert formatter to flake-parts module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,7 +446,7 @@ Tools using `nix-wrapper-modules.wrappers.*`:
 - [x] **Step 1**: Add flake-parts, import-tree, nix-wrapper-modules inputs
 - [x] **Step 2**: Create directory structure and move static configs
 - [x] **Step 3**: Convert overlays to flake-parts module
-- [ ] Step 4: Convert formatter to flake-parts module
+- [x] **Step 4**: Convert formatter to flake-parts module
 - [ ] Step 5: Convert development shells to flake-parts modules
 - [ ] Step 6: Split core.nix into feature modules
 - [ ] Step 7: Convert shell tools to wrapper-modules

--- a/flake.nix
+++ b/flake.nix
@@ -228,8 +228,6 @@
               ];
             };
           };
-
-          formatter.${system} = pkgs.nixfmt-rfc-style;
         };
       }
     );

--- a/modules/flake/formatter.nix
+++ b/modules/flake/formatter.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  perSystem = { pkgs, ... }: {
+    formatter = pkgs.nixfmt-rfc-style;
+  };
+}


### PR DESCRIPTION
## Summary

- Moves `formatter.${system} = pkgs.nixfmt-rfc-style` out of the inline `flake = { ... }` block in `flake.nix`
- Creates `modules/flake/formatter.nix` as a flake-parts perSystem module, auto-discovered by import-tree
- Step 4 of the dendritic pattern migration

## Test plan

- [ ] `nix flake show` lists `formatter.x86_64-linux`
- [ ] `nix fmt` formats `.nix` files with `nixfmt-rfc-style`
- [ ] `nix flake check` passes