### PR TITLE
feat(dendritic): add R1 core scaffolding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,12 @@
 {
   description = "System Config";
 
+  # `modules/nixos.nix` uses the `|>` pipe operator at flake-eval time. This nixConfig
+  # copy is untrusted, so the first build/check (before the nix-settings change is
+  # active) must pass `--accept-flake-config` or `--extra-experimental-features
+  # pipe-operators`.
+  nixConfig.extra-experimental-features = [ "pipe-operators" ];
+
   inputs = {
     # Core nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
@@ -80,6 +86,14 @@
         imports = [
           (inputs.import-tree ./modules/flake)
           (inputs.import-tree ./modules/features/shell)
+          # Dendritic core scaffolding (R1). Imported explicitly rather than via
+          # import-tree so the legacy modules/{features/core,nixos} stay out of scope
+          # until later steps; import-tree widens to all of ./modules at R6.
+          ./modules/eval-modules.nix
+          ./modules/nixos.nix
+          ./modules/home-manager.nix
+          ./modules/nixpkgs.nix
+          ./modules/users.nix
         ];
         systems = [ "x86_64-linux" ];
 

--- a/modules/eval-modules.nix
+++ b/modules/eval-modules.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+{
+  _module.args.evalModulesModule =
+    { config, ... }:
+    {
+      options = {
+        fn = lib.mkOption { type = lib.types.functionTo lib.types.attrs; };
+        module = lib.mkOption { type = lib.types.deferredModule; };
+        args = lib.mkOption {
+          type = lib.types.lazyAttrsOf lib.types.anything;
+          default = { };
+        };
+        evaluation = lib.mkOption {
+          readOnly = true;
+          type = lib.types.attrs;
+          default = config.fn (config.args // { modules = [ config.module ]; });
+        };
+      };
+    };
+}

--- a/modules/features/core/nix-settings.nix
+++ b/modules/features/core/nix-settings.nix
@@ -13,6 +13,7 @@
       experimental-features = [
         "nix-command"
         "flakes"
+        "pipe-operators"
       ];
       substituters = [
         "https://cache.nixos.org/"

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+{
+  options.homeManager.modules = lib.mkOption {
+    type = lib.types.lazyAttrsOf lib.types.deferredModule;
+    default = { };
+  };
+  config.homeManager.modules = {
+    base = {
+      programs.home-manager.enable = true;
+    };
+    gui = { };
+  };
+}

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  inputs,
+  evalModulesModule,
+  ...
+}:
+let
+  cfg = config.nixos;
+in
+{
+  options.nixos = {
+    modules = lib.mkOption {
+      type = lib.types.lazyAttrsOf lib.types.deferredModule;
+      default = { };
+    };
+    configurations = lib.mkOption {
+      type = lib.types.lazyAttrsOf (
+        lib.types.submodule (
+          { name, ... }:
+          {
+            imports = [
+              evalModulesModule
+              {
+                fn = inputs.nixpkgs.lib.nixosSystem;
+                module = {
+                  networking.hostName = lib.mkDefault name;
+                };
+              }
+            ];
+          }
+        )
+      );
+      default = { };
+    };
+  };
+
+  config.flake = {
+    nixosConfigurations = cfg.configurations |> lib.mapAttrs (_: c: c.evaluation);
+    checks =
+      cfg.configurations
+      |> lib.mapAttrsToList (
+        name: c: {
+          ${c.evaluation.config.nixpkgs.hostPlatform.system}."configurations:nixos:${name}" =
+            c.evaluation.config.system.build.toplevel;
+        }
+      )
+      |> lib.mkMerge;
+  };
+}

--- a/modules/nixpkgs.nix
+++ b/modules/nixpkgs.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+let
+  nixpkgsSettings = {
+    config.allowUnfree = true;
+    overlays = [ config.flake.overlays.default ];
+  };
+in
+{
+  # NOTE: perSystem `_module.args.pkgs` is intentionally NOT set here; it is already
+  # defined in modules/flake/overlays.nix (defining a module arg twice errors). The
+  # overlays move into this file at R6, alongside removing the legacy definition.
+  nixos.modules.base = {
+    nixpkgs = nixpkgsSettings;
+  };
+}

--- a/modules/users.nix
+++ b/modules/users.nix
@@ -1,0 +1,25 @@
+{ config, inputs, ... }:
+{
+  config = {
+    nixos.modules.base = {
+      imports = [ inputs.home-manager.nixosModules.home-manager ];
+      users.users.tguimbert = {
+        isNormalUser = true;
+        uid = 1000;
+      };
+      home-manager = {
+        useGlobalPkgs = true;
+        useUserPackages = true;
+        users.tguimbert =
+          { osConfig, ... }:
+          {
+            home.stateVersion = osConfig.system.stateVersion;
+            imports = [ config.homeManager.modules.base ];
+          };
+      };
+    };
+    nixos.modules.desktop = {
+      home-manager.users.tguimbert.imports = [ config.homeManager.modules.gui ];
+    };
+  };
+}


### PR DESCRIPTION
Add the dendritic-pattern framework modules (flat under modules/),
purely additive alongside the existing mkSystem builders:

- eval-modules.nix: evalModulesModule helper (lazy nixosSystem evaluator)
- nixos.nix: nixos.modules / nixos.configurations options + central
  generation into flake.nixosConfigurations and flake.checks
- home-manager.nix: homeManager.modules option, seeds base/gui
- nixpkgs.nix: nixos.modules.base nixpkgs settings (allowUnfree + overlays)
- users.nix: single-user home-manager wiring into base/desktop

Wire the five files via explicit imports in flake.nix (not import-tree,
so legacy modules/{features/core,nixos} stay out of scope until later
steps). Enable pipe-operators in nix-settings.nix and flake.nix nixConfig
since nixos.nix uses the |> operator at eval time.

No host is migrated; nixos.configurations is empty, so the new generator
merges cleanly with the legacy nixosConfigurations.
