### PR TITLE
feat(leshen): enable zfs filesystem support

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -183,7 +183,24 @@
         autoContext = true;
         confirmDestructiveActions = true;
         statusLine = {
-          command = "input=$(cat); echo \"[$(echo \"$input\" | jq -r '.model.display_name')] 📁 $(basename \"$(echo \"$input\" | jq -r '.workspace.current_dir')\")\"";
+          command = ''
+            input=$(cat)
+            model=$(echo "$input" | jq -r '.model.display_name')
+            dir=$(echo "$input" | jq -r '.workspace.current_dir' | sed "s|$HOME|~|")
+            branch=$(git -C "$(echo "$input" | jq -r '.workspace.current_dir')" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
+            used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+            orange="\033[38;5;214m"
+            byellow="\033[38;5;178m"
+            bcyan="\033[38;5;72m"
+            bblack="\033[38;5;239m"
+            reset="\033[0m"
+            out=""
+            out="$out$(printf "$orange $model $reset")"
+            out="$out$(printf "  $byellow $dir $reset")"
+            [ -n "$branch" ] && out="$out$(printf "  $bcyan $branch $reset")"
+            [ -n "$used" ] && out="$out$(printf "  $bblack ctx:$(printf '%.0f' "$used")%% $reset")"
+            printf "%b" "$out"
+          '';
           padding = 0;
           type = "command";
         };

--- a/hosts/leshen/hardware.nix
+++ b/hosts/leshen/hardware.nix
@@ -1,20 +1,35 @@
-{ config, lib, modulesPath, ... }:
+{
+  config,
+  lib,
+  modulesPath,
+  ...
+}:
 
 {
-  imports =
-    [
-      (modulesPath + "/installer/scan/not-detected.nix")
-    ];
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
 
   boot = {
     initrd = {
-      availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usb_storage" "usbhid" "sd_mod" ];
+      availableKernelModules = [
+        "nvme"
+        "xhci_pci"
+        "ahci"
+        "usb_storage"
+        "usbhid"
+        "sd_mod"
+      ];
       kernelModules = [ ];
     };
     kernelModules = [ "kvm-amd" ];
     extraModulePackages = [ ];
+
+    supportedFilesystems = [ "zfs" ];
+    zfs.forceImportRoot = false;
   };
 
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
-}
 
+  networking.hostId = "42dea791";
+}


### PR DESCRIPTION
Move zfs boot config (supportedFilesystems, forceImportRoot) out of the
shared core boot module so it only applies to leshen, alongside its
networking.hostId.
