### PR TITLE
feat(dendritic): migrate leshen to nixos.configurations (R2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,8 @@
         imports = [
           (inputs.import-tree ./modules/flake)
           (inputs.import-tree ./modules/features/shell)
+          # R2: leshen migrated to nixos.configurations (modules/machines/leshen.nix).
+          (inputs.import-tree ./modules/machines)
           # Dendritic core scaffolding (R1). Imported explicitly rather than via
           # import-tree so the legacy modules/{features/core,nixos} stay out of scope
           # until later steps; import-tree widens to all of ./modules at R6.
@@ -170,19 +172,8 @@
               };
           in
           {
+            # leshen is built via nixos.configurations (modules/machines/leshen.nix) as of R2.
             nixosConfigurations = {
-              leshen = mkSystem "leshen" [
-                ./hosts/leshen/hardware.nix
-                ./hosts/leshen/disks.nix
-                ./modules/nixos/impermanence.nix
-                ./modules/nixos/gnome.nix
-                ./modules/nixos/games.nix
-                ./modules/nixos/podman.nix
-
-                {
-                  system.stateVersion = "22.11";
-                }
-              ];
               griffin = mkSystem "griffin" [
                 inputs.nixos-hardware.nixosModules.lenovo-thinkpad-t490
                 ./hosts/griffin/hardware.nix

--- a/modules/machines/leshen.nix
+++ b/modules/machines/leshen.nix
@@ -1,0 +1,55 @@
+{ config, inputs, ... }:
+{
+  nixos.configurations.leshen = {
+    # Provide `inputs` to legacy NixOS modules (parity with the old mkSystem specialArgs).
+    # Removed once these features become closure-based aspects (R3/R4/R8+).
+    args.specialArgs = { inherit inputs; };
+
+    module = {
+      imports =
+        (with config.nixos.modules; [
+          base
+          desktop
+        ])
+        ++ [
+          # Global modules formerly injected by mkSystem (move to merge points in R3/R4/R8).
+          (inputs.import-tree ../features/core)
+          inputs.self.nixosModules.terminal
+          inputs.self.nixosModules.helix
+          inputs.self.nixosModules.nushell
+          inputs.self.nixosModules.zellij
+          inputs.self.nixosModules.starship
+          inputs.self.nixosModules.cli-tools
+          inputs.disko.nixosModules.disko
+          inputs.lanzaboote.nixosModules.lanzaboote
+          inputs.impermanence.nixosModules.impermanence
+          inputs.sops-nix.nixosModules.sops
+          inputs.stylix.nixosModules.stylix
+
+          # leshen-specific legacy modules (move to machines/ + named aspects later).
+          ../../hosts/leshen/hardware.nix
+          ../../hosts/leshen/disks.nix
+          ../nixos/impermanence.nix
+          ../nixos/gnome.nix
+          ../nixos/games.nix
+          ../nixos/podman.nix
+        ];
+
+      nixpkgs.hostPlatform = "x86_64-linux";
+
+      # Legacy home wiring (moves into homeManager.modules.{base,gui} in R4/R8). The `base`
+      # merge point already imports the home-manager NixOS module, sets useGlobalPkgs /
+      # useUserPackages, and seeds users.tguimbert.imports with homeManager.modules.base; the
+      # blocks below merge arkenfox + ./home into that.
+      home-manager = {
+        extraSpecialArgs = { inherit inputs; };
+        users.tguimbert.imports = [
+          inputs.arkenfox-nix.modules.homeManager.arkenfox
+          ../../home
+        ];
+      };
+
+      system.stateVersion = "22.11";
+    };
+  };
+}


### PR DESCRIPTION
Route the canary host through the dendritic nixos.configurations
generation path instead of the legacy mkSystem builder. The host module
imports the base + desktop merge points plus the same global/host modules
mkSystem injected (referenced by path until R3/R4/R8+ convert them to
aspects). griffin/tuxedo/srv-01 stay on mkSystem until R5.

The resulting toplevel derivation is byte-for-byte identical, so this is
a pure mechanism switch.
