### PR TITLE
feat(dendritic): migrate security features (R9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,7 +646,7 @@ Steps 1–7 of the original plan are merged but use the superseded pattern; R1�
 - [x] **R6**: Cutover entry point (`outputs.nix`, single `import-tree ./modules`; legacy `modules/nixos/` → `_nixos/`; specialArgs deferred to R13)
 - [x] **R7**: Dev tools
 - [x] **R8**: Desktop features (gnome/stylix/firefox → `modules/desktop/`; dropped per-machine `specialArgs`/`extraSpecialArgs`)
-- [ ] **R9**: Security features
+- [x] **R9**: Security features (lanzaboote/sops → flat `modules/{lanzaboote,sops}.nix`; sops input on `base`, lanzaboote + desktop sops defaults on `desktop`; dropped security input-imports from machines; srv-01 sops/services baseline deferred to R12)
 - [ ] **R10**: Impermanence features
 - [ ] **R11**: Virtualization features
 - [ ] **R12**: Gaming + work + server services

--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -1,41 +1,24 @@
 { ... }:
 {
-  nixos.modules.desktop =
-    { pkgs, ... }:
-    {
-      boot = {
-        loader = {
-          systemd-boot.enable = false;
-          efi = {
-            canTouchEfiVariables = true;
-            efiSysMountPoint = "/boot";
-          };
-          timeout = 0;
-        };
-        lanzaboote = {
-          enable = true;
-          pkiBundle = "/etc/secureboot";
-        };
-        bootspec.enable = true;
-        tmp.useTmpfs = true;
-        initrd.systemd.enable = true;
-        binfmt.emulatedSystems = [ "aarch64-linux" ];
+  nixos.modules.desktop = {
+    boot = {
+      tmp.useTmpfs = true;
+      initrd.systemd.enable = true;
+      binfmt.emulatedSystems = [ "aarch64-linux" ];
 
-        plymouth.enable = true;
-        # Enable "Silent Boot"
-        consoleLogLevel = 0;
-        initrd.verbose = false;
-        kernelParams = [
-          "quiet"
-          "splash"
-          "boot.shell_on_fail"
-          "loglevel=3"
-          "rd.systemd.show_status=false"
-          "rd.udev.log_level=3"
-          "udev.log_priority=3"
-        ];
-      };
-
-      environment.systemPackages = [ pkgs.sbctl ];
+      plymouth.enable = true;
+      # Enable "Silent Boot"
+      consoleLogLevel = 0;
+      initrd.verbose = false;
+      kernelParams = [
+        "quiet"
+        "splash"
+        "boot.shell_on_fail"
+        "loglevel=3"
+        "rd.systemd.show_status=false"
+        "rd.udev.log_level=3"
+        "udev.log_priority=3"
+      ];
     };
+  };
 }

--- a/modules/lanzaboote.nix
+++ b/modules/lanzaboote.nix
@@ -1,0 +1,26 @@
+{ inputs, ... }:
+{
+  nixos.modules.desktop =
+    { pkgs, ... }:
+    {
+      imports = [ inputs.lanzaboote.nixosModules.lanzaboote ];
+
+      boot = {
+        loader = {
+          systemd-boot.enable = false;
+          efi = {
+            canTouchEfiVariables = true;
+            efiSysMountPoint = "/boot";
+          };
+          timeout = 0;
+        };
+        lanzaboote = {
+          enable = true;
+          pkiBundle = "/etc/secureboot";
+        };
+        bootspec.enable = true;
+      };
+
+      environment.systemPackages = [ pkgs.sbctl ];
+    };
+}

--- a/modules/machines/griffin.nix
+++ b/modules/machines/griffin.nix
@@ -9,9 +9,7 @@
         ])
         ++ [
           inputs.disko.nixosModules.disko
-          inputs.lanzaboote.nixosModules.lanzaboote
           inputs.impermanence.nixosModules.impermanence
-          inputs.sops-nix.nixosModules.sops
 
           inputs.nixos-hardware.nixosModules.lenovo-thinkpad-t490
           ../../hosts/griffin/hardware.nix

--- a/modules/machines/leshen.nix
+++ b/modules/machines/leshen.nix
@@ -9,9 +9,7 @@
         ])
         ++ [
           inputs.disko.nixosModules.disko
-          inputs.lanzaboote.nixosModules.lanzaboote
           inputs.impermanence.nixosModules.impermanence
-          inputs.sops-nix.nixosModules.sops
 
           # leshen-specific legacy modules (move to machines/ + named aspects later).
           ../../hosts/leshen/hardware.nix

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -13,7 +13,6 @@
         ++ [
           inputs.disko.nixosModules.disko
           inputs.impermanence.nixosModules.impermanence
-          inputs.sops-nix.nixosModules.sops
 
           ../../hosts/srv-01/hardware.nix
           ../../hosts/srv-01/disks.nix

--- a/modules/machines/tuxedo.nix
+++ b/modules/machines/tuxedo.nix
@@ -9,9 +9,7 @@
         ])
         ++ [
           inputs.disko.nixosModules.disko
-          inputs.lanzaboote.nixosModules.lanzaboote
           inputs.impermanence.nixosModules.impermanence
-          inputs.sops-nix.nixosModules.sops
 
           inputs.nixos-hardware.nixosModules.tuxedo-infinitybook-pro14-gen9-intel
           inputs.tuxedo-nixos.nixosModules.default

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -19,11 +19,6 @@
         };
       };
 
-      sops = {
-        defaultSopsFile = ../secrets/common.yaml;
-        age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
-      };
-
       xdg.portal = {
         enable = true;
         extraPortals = with pkgs; [

--- a/modules/sops.nix
+++ b/modules/sops.nix
@@ -1,0 +1,13 @@
+{ inputs, ... }:
+{
+  nixos.modules.base = {
+    imports = [ inputs.sops-nix.nixosModules.sops ];
+  };
+
+  nixos.modules.desktop = {
+    sops = {
+      defaultSopsFile = ../secrets/common.yaml;
+      age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+  };
+}


### PR DESCRIPTION
Extract lanzaboote (secure boot) and sops (secrets) wiring out of the
machine files and the boot/services collectors into dedicated dendritic
feature modules.

- modules/lanzaboote.nix: lanzaboote input import + secure-boot config
  (loader/efi, boot.lanzaboote, bootspec, sbctl) on nixos.modules.desktop
- modules/sops.nix: sops-nix input on nixos.modules.base (all hosts);
  desktop sops defaults (common.yaml, age key) on nixos.modules.desktop
- modules/boot.nix: keep only generic boot config (tmpfs, plymouth,
  silent-boot kernelParams, binfmt, initrd.systemd)
- modules/services.nix: drop the sops defaults block (moved to sops.nix)
- machines: drop the now-redundant lanzaboote/sops-nix input imports

srv-01's own sops baseline (defaultSopsFile, age key, hashed-password)
and per-service secrets stay in hosts/srv-01/* and migrate in R12; they
keep working via the base sops-nix import.
