### PR TITLE
niri noctalia followups

### DIFF
--- a/modules/desktop/stylix.nix
+++ b/modules/desktop/stylix.nix
@@ -19,13 +19,17 @@
           size = 24;
         };
         fonts = {
+          # One UI sans for the whole desktop: stylix themes GTK/GNOME with it and
+          # noctalia's bar inherits it (modules/niri/noctalia.nix). Inter is drawn for
+          # screen UI — it stays legible at bar sizes where Lato went soft. serif
+          # mirrors it, as it did with Lato: no serifs anywhere.
           sansSerif = {
-            package = pkgs.lato;
-            name = "Lato";
+            package = pkgs.inter;
+            name = "Inter";
           };
           serif = {
-            package = pkgs.lato;
-            name = "Lato";
+            package = pkgs.inter;
+            name = "Inter";
           };
           monospace = {
             package = pkgs.nerd-fonts.iosevka-term;

--- a/modules/locale.nix
+++ b/modules/locale.nix
@@ -4,6 +4,13 @@
     time.timeZone = "Europe/Paris";
     i18n = {
       defaultLocale = "en_US.UTF-8";
+
+      # GNOME's nixpkgs module switches ibus on by default, but no input method is
+      # wanted here: no engines are configured and the layouts below are plain xkb,
+      # which niri and GNOME drive themselves. Off also drops GTK_IM_MODULE /
+      # QT_IM_MODULE, so GTK and Qt apps take Wayland's text-input-v3 instead.
+      inputMethod.enable = false;
+
       extraLocaleSettings = {
         LC_ADDRESS = "fr_FR.UTF-8";
         LC_IDENTIFICATION = "fr_FR.UTF-8";
@@ -19,7 +26,7 @@
 
     services.xserver = {
       # us(intl) primary, fr(oss) (AZERTY) as an alternative; toggle with
-      # Scroll Lock (KC_SCRL on a Miryoku layer). Mirrored in niri (modules/niri.nix).
+      # Scroll Lock (KC_SCRL on a Miryoku layer). Mirrored in modules/niri/niri.nix.
       xkb = {
         layout = "us,fr";
         variant = "intl,oss";

--- a/modules/niri/niri.nix
+++ b/modules/niri/niri.nix
@@ -155,6 +155,11 @@
           QT_QPA_PLATFORM = "wayland;xcb";
         };
 
+        # Without this, apps launched from noctalia's launcher open unfocused
+        # (upstream's recommendation). An empty argument list is how niri-flake
+        # spells a no-argument `debug` node.
+        debug.honor-xdg-activation-with-invalid-serial = [ ];
+
         # Window rules — matched top-to-bottom, later rules layer over earlier.
         window-rules = [
           # Rounded corners for every window, clipped to the rounded shape.
@@ -179,9 +184,37 @@
             ];
             open-floating = true;
           }
+          {
+            matches = [
+              {
+                app-id = "^firefox$";
+                title = "^Extension: \\(Bitwarden";
+              }
+            ];
+            open-floating = true;
+          }
+          # noctalia's own window (its settings UI when opened windowed rather than as
+          # a panel) floats at the size upstream recommends, instead of taking a column.
+          {
+            matches = [ { app-id = "^dev\\.noctalia\\.Noctalia$"; } ];
+            open-floating = true;
+            default-column-width.fixed = 1080;
+            default-window-height.fixed = 920;
+          }
           # Template for keeping secrets out of screencasts (noctalia screen-share,
           # OBS): add a rule matching your password manager's app-id and set
           # `block-out-from = "screencast";` — left empty until one is installed.
+        ];
+
+        # Puts noctalia's blurred wallpaper behind the overview and the gaps between
+        # workspaces, in place of niri's flat backdrop colour. It paints that on a
+        # *second* background surface — distinct from the plain noctalia-wallpaper one
+        # — which exists only while `backdrop.enabled` is set in ./noctalia.nix.
+        layer-rules = [
+          {
+            matches = [ { namespace = "^noctalia-backdrop"; } ];
+            place-within-backdrop = true;
+          }
         ];
 
         # Dual 2560x1440 @ scale 1, side by side. DP-1 (XF270HU, 144 Hz + VRR) is

--- a/modules/niri/niri.nix
+++ b/modules/niri/niri.nix
@@ -31,16 +31,26 @@
       users.users.tguimbert.extraGroups = [ "i2c" ];
       environment.systemPackages = [ pkgs.ddcutil ];
 
-      # config.toml is declaratively managed by home-manager (read-only symlink),
-      # so this only preserves noctalia's runtime state (clipboard history,
-      # screen-time, wallpaper selection) across the tmpfs-root reboots.
+      # NB: noctalia 5 keeps its runtime state (settings overrides, wallpaper choice,
+      # notification history, wizard marker) in ~/.local/state/noctalia — this dir
+      # holds only HM symlinks now, so the entry carries nothing. Preserve the state
+      # dir instead if that state should survive.
       preservation.preserveAt."/persistent".users.tguimbert.directories = [
         ".config/noctalia"
-        # niri writes screenshots here (screenshot-path); keep them across the
-        # tmpfs-root reboots.
+        # where screenshot-path (below) writes
         "Pictures/Screenshots"
       ];
     };
+
+  # Hands the lid to the compositor so it can lock *before* suspending (the
+  # switch-events bind below) instead of racing logind and resuming unlocked. Opt-in
+  # per host rather than part of `niri`: logind is system-wide, so on a host that
+  # also offers the GNOME session this takes the lid away from GNOME too. Import
+  # next to `niri` from a laptop machine file (griffin, once it moves off GNOME).
+  nixos.modules.niriLaptop.services.logind.settings.Login = {
+    HandleLidSwitch = "ignore";
+    HandleLidSwitchExternalPower = "ignore";
+  };
 
   # Compositor half of the home-manager `niri` aspect (./noctalia.nix adds the
   # shell/theming half).
@@ -58,20 +68,14 @@
       # playerctl backs the XF86Audio{Play,Next,Prev} media-key binds below.
       home.packages = [ pkgs.playerctl ];
 
-      # niri itself: noctalia ships a builtin `niri` template (enabled via
-      # builtin_ids in ./noctalia.nix). Its apply.sh *only* injects
-      # `include "noctalia.kdl"` into ~/.config/niri/config.kdl — it never writes
-      # the colors file; the template engine renders that to
-      # ~/.config/niri/noctalia.kdl separately. Our config.kdl is a read-only HM
-      # symlink apply.sh can't edit, so declare the include ourselves: apply.sh
-      # greps for an existing `…noctalia.kdl` include, finds this one, and skips
-      # its write (same trick as foot in ./noctalia.nix). `optional=true` so a
-      # fresh tmpfs boot — before noctalia has rendered noctalia.kdl — doesn't
-      # fail the parse; niri watches the (real, non-symlink) included file and
-      # live-reloads once it appears and on every later palette/mode change, so no
-      # reload hook is needed. Appended to the settings-rendered finalConfig so the
-      # structured programs.niri.settings config is preserved (referencing
-      # finalConfig, not config, avoids a cycle).
+      # noctalia's builtin `niri` template renders the colors to
+      # ~/.config/niri/noctalia.kdl, and its apply.sh injects the include into
+      # config.kdl — which it can't do here, ours being a read-only HM symlink. So
+      # declare the include ourselves; apply.sh greps for one and skips its write.
+      # `optional=true` survives a fresh tmpfs boot with the file not yet rendered,
+      # and niri live-reloads once it appears, so no reload hook is needed. Appending
+      # to finalConfig (not config, which would cycle) keeps the structured settings
+      # below.
       xdg.configFile.niri-config.source = lib.mkForce (
         pkgs.writeText "niri-config.kdl" ''
           ${config.programs.niri.finalConfig}
@@ -135,10 +139,9 @@
           ];
         };
 
-        # Don't pop the hotkey cheatsheet on every login (Mod+Shift+Slash shows it
-        # on demand). Disable the overview hot-corner; Mod+O toggles it instead.
+        # Mod+Shift+Slash still shows the cheatsheet on demand.
         hotkey-overlay.skip-at-startup = true;
-        gestures.hot-corners.enable = false;
+        gestures.hot-corners.enable = true;
 
         # Interactive (Mod+Print) and full screen/window screenshots land here,
         # timestamped so they sort. ~/Pictures/Screenshots is preserved in the
@@ -155,6 +158,16 @@
           QT_QPA_PLATFORM = "wayland;xcb";
         };
 
+        # Needs `niriLaptop` (above) to take the lid off logind. Inert on leshen,
+        # which has no lid switch, like the touchpad settings above. Switch binds
+        # accept nothing but spawn actions.
+        switch-events.lid-close.action.spawn = [
+          "noctalia"
+          "msg"
+          "session"
+          "lock-and-suspend"
+        ];
+
         # Without this, apps launched from noctalia's launcher open unfocused
         # (upstream's recommendation). An empty argument list is how niri-flake
         # spells a no-argument `debug` node.
@@ -162,7 +175,6 @@
 
         # Window rules — matched top-to-bottom, later rules layer over earlier.
         window-rules = [
-          # Rounded corners for every window, clipped to the rounded shape.
           {
             geometry-corner-radius =
               let
@@ -251,7 +263,6 @@
           };
         };
 
-        # X11 support for apps that don't speak Wayland (Steam games, etc.).
         xwayland-satellite = {
           enable = true;
           path =
@@ -326,7 +337,6 @@
           "Mod+BracketLeft".action = consume-or-expel-window-left;
           "Mod+BracketRight".action = consume-or-expel-window-right;
 
-          # column / window sizing
           "Mod+Minus".action = set-column-width "-10%";
           "Mod+Equal".action = set-column-width "+10%";
           "Mod+Shift+Minus".action = set-window-height "-10%";
@@ -334,7 +344,6 @@
           "Mod+Ctrl+F".action = expand-column-to-available-width;
           "Mod+C".action = center-column;
 
-          # tabbed columns + floating
           "Mod+W".action = toggle-column-tabbed-display;
           "Mod+V".action = toggle-window-floating;
           "Mod+Shift+V".action = switch-focus-between-floating-and-tiling;
@@ -346,10 +355,9 @@
           "Mod+Ctrl+Shift+Left".action = move-column-to-monitor-left;
           "Mod+Ctrl+Shift+Right".action = move-column-to-monitor-right;
 
-          # overview (Mod+O; hot-corner disabled above)
+          # the hot corner (enabled above) toggles this too
           "Mod+O".action = toggle-overview;
 
-          # workspaces — focus, plus move the column/workspace itself.
           "Mod+Page_Down".action = focus-workspace-down;
           "Mod+Page_Up".action = focus-workspace-up;
           "Mod+1".action = focus-workspace 1;
@@ -380,7 +388,7 @@
           "Ctrl+Print".action.screenshot-screen = { };
           "Alt+Print".action.screenshot-window = { };
 
-          # volume routed through noctalia (mpris) so its OSD shows.
+          # volume through noctalia so its OSD shows.
           "XF86AudioRaiseVolume" = {
             action = spawn "noctalia" "msg" "volume-up";
             hotkey-overlay.title = "Volume up";

--- a/modules/niri/noctalia.nix
+++ b/modules/niri/noctalia.nix
@@ -540,6 +540,13 @@
               # bundled tabler.ttf, so no nerd-font coverage is needed here. Inheriting
               # stylix's sans keeps the shell on the same font as the GTK apps.
               font_family = lib.mkDefault config.stylix.fonts.sansSerif.name;
+
+              # The wizard's only "already done" marker lives in ~/.local/state, which
+              # the tmpfs root wipes, so it would run at every login — and what it asks
+              # for (palette, wallpaper, bar) is declarative here anyway.
+              setup_wizard_enabled = false;
+
+              niri_overview_type_to_launch_enabled = true;
             };
 
             # External-monitor brightness over DDC/CI (gated off by default in

--- a/modules/niri/noctalia.nix
+++ b/modules/niri/noctalia.nix
@@ -14,9 +14,8 @@
       ...
     }:
     let
-      # Palette placeholder that resolves to the active light/dark mode. Shared by
-      # the starship + Claude Code templates below (both map noctalia's palette
-      # onto their own color slots with the exact same `.default` mode ref).
+      # `.default` is noctalia's placeholder for whichever mode is active. Shared by
+      # the starship + Claude Code templates below.
       activeColor = name: "{{colors.${name}.default.hex}}";
 
       # Vendored Gruvbox Material palette (dark + light + terminal colors) — the
@@ -28,6 +27,8 @@
       # {{colors.terminal_*}} placeholders) to ~/.cache/terminal-sequences and the
       # post_hook tees it to every PTY. printf emits the raw ESC/BEL bytes at build
       # time; the {{…}} placeholders pass through untouched for noctalia to fill.
+      # This covers palette changes; a mode flip goes through foot's own theme switch
+      # (the SIGUSR post_hook below).
       terminalSequences = pkgs.runCommand "noctalia-terminal-sequences.tmpl" { } ''
         {
           printf '\033]10;{{colors.terminal_foreground.default.hex}}\007'
@@ -54,11 +55,92 @@
         } > $out
       '';
 
-      # zellij theme — one template emits BOTH `noctalia-dark` and
-      # `noctalia-light` blocks (explicit .dark/.light color refs, so the file is
-      # mode-independent and loads at startup). zellij can't hot-reload theme
-      # files, so the template's post_hook flips the *active* theme per session
-      # via the CLI action, deterministically from the {{ mode }} placeholder.
+      # Three consumers — noctalia renders it, foot includes it, activation places it
+      # — and a mismatch between them costs foot its *entire* config, since a missing
+      # include aborts the parse and takes the font and shell down with the colors.
+      # Absolute, as the activation script needs.
+      footThemeFile = "${config.xdg.configHome}/foot/themes/noctalia";
+
+      # foot theme — replaces noctalia's builtin foot template, which emits a single
+      # `[colors-dark]` section holding whatever mode was active at render time, so
+      # foot's own dark/light switch had nothing to switch to. Emit both sections with
+      # explicit .dark/.light refs (mode-independent, like the zellij theme below) and
+      # let foot choose: `initial-color-theme` at startup, SIGUSR1/SIGUSR2 for a
+      # running server (the post_hook). Keys mirror the upstream builtin template.
+      # `color` resolves a noctalia `terminal_*` name to a bare RRGGBB value, which is
+      # all foot.ini(5) accepts — from a placeholder for noctalia, or from the vendored
+      # palette for the fallback below.
+      mkFootColors =
+        mode: color:
+        let
+          ansiNames = [
+            "black"
+            "red"
+            "green"
+            "yellow"
+            "blue"
+            "magenta"
+            "cyan"
+            "white"
+          ];
+        in
+        lib.concatStringsSep "\n" (
+          [
+            "[colors-${mode}]"
+            "foreground=${color "foreground"}"
+            "background=${color "background"}"
+          ]
+          ++ lib.imap0 (i: name: "regular${toString i}=${color "normal_${name}"}") ansiNames
+          ++ lib.imap0 (i: name: "bright${toString i}=${color "bright_${name}"}") ansiNames
+          ++ [
+            "selection-foreground=${color "selection_fg"}"
+            "selection-background=${color "selection_bg"}"
+            "cursor=${color "cursor_text"} ${color "cursor"}"
+          ]
+        );
+
+      mkFootTheme = initialTheme: color: ''
+        [main]
+        initial-color-theme=${initialTheme}
+        ${mkFootColors "dark" (color "dark")}
+        ${mkFootColors "light" (color "light")}
+      '';
+
+      footThemeTemplate = pkgs.writeText "noctalia-foot.tmpl" (
+        mkFootTheme "{{ mode }}" (mode: name: "{{colors.terminal_${name}.${mode}.hex_stripped}}")
+      );
+
+      # The same file resolved from the vendored palette instead of placeholders,
+      # because the foot server starts with graphical-session.target — a moment
+      # *before* niri's noctalia has rendered anything. Not state: rebuilt from this
+      # palette on every activation, which runs at boot, before the session. `dark` is
+      # just the mode foot opens in until the first render signals the live one.
+      footThemeFallback = pkgs.writeText "noctalia-foot-theme" (
+        mkFootTheme "dark" (
+          mode:
+          let
+            terminal = gruvboxMaterial.${mode}.terminal;
+            byName = {
+              inherit (terminal) foreground background cursor;
+              cursor_text = terminal.cursorText;
+              selection_fg = terminal.selectionFg;
+              selection_bg = terminal.selectionBg;
+            }
+            // lib.concatMapAttrs (name: hex: { "normal_${name}" = hex; }) terminal.normal
+            // lib.concatMapAttrs (name: hex: { "bright_${name}" = hex; }) terminal.bright;
+          in
+          name: lib.removePrefix "#" byName.${name}
+        )
+      );
+
+      # zellij theme — one template emits three blocks: `noctalia-dark` and
+      # `noctalia-light` (explicit .dark/.light refs, so the file is mode-independent
+      # and loads at startup) plus `noctalia`, the active mode via `.default`. zellij
+      # picks its theme from the read-only config.kdl, which can't follow the mode, so
+      # `theme "noctalia"` gives a *newly started* session the live palette; the
+      # -dark/-light pair backs the switch for sessions already running, which the
+      # post_hook drives from the {{ mode }} placeholder (zellij can't hot-reload theme
+      # files, and its own dark/light detection only reacts to a later flip).
       mkZellijTheme =
         mode:
         let
@@ -120,6 +202,9 @@
 
       zellijThemeTemplate = pkgs.writeText "noctalia-zellij.kdl.tmpl" ''
         themes {
+          noctalia {
+        ${mkZellijTheme "default"}
+          }
           noctalia-dark {
         ${mkZellijTheme "dark"}
           }
@@ -298,19 +383,26 @@
         run ${config.programs.noctalia.package}/bin/noctalia firefox-theme install
       '';
 
+      # Put footThemeFallback in place before the session; noctalia overwrites it with
+      # the live palette seconds later. Skipped when the file exists so a mid-session
+      # `nh os switch` doesn't revert a runtime palette change.
+      home.activation.footNoctaliaTheme = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        [ -e "${footThemeFile}" ] || run install -Dm644 ${footThemeFallback} "${footThemeFile}"
+      '';
+
       programs = {
-        # Point each app at noctalia's rendered side theme file. Declaring the link
-        # here (instead of letting noctalia's apply.sh edit the read-only HM config)
-        # keeps it declarative — foot's apply.sh sees the include already present
-        # and skips its own edit; helix has no hook and just loads the named theme.
-        foot.settings.main.include = "~/.config/foot/themes/noctalia";
+        # Point each app at the theme file noctalia renders for it. Declaring this
+        # ourselves keeps it declarative: foot is a user template now, so no apply.sh
+        # runs for it; helix has no hook and just loads the named theme.
+        foot.settings.main.include = footThemeFile;
         helix.settings.theme = "noctalia";
 
-        # zellij: noctalia writes both theme blocks to themes/noctalia.kdl; select
-        # them as the dark/light themes and the template post_hook flips the active
-        # one live. `theme` is forced off the shared module's "stylix".
+        # zellij: `noctalia` is the live-mode block, so a session started at any point
+        # opens on the current palette; the dark/light pair is what the post_hook (and
+        # zellij's own detection) switches a running session to. `theme` is forced off
+        # the shared module's "stylix".
         zellij.settings = {
-          theme = lib.mkForce "noctalia-dark";
+          theme = lib.mkForce "noctalia";
           theme_dark = "noctalia-dark";
           theme_light = "noctalia-light";
         };
@@ -321,20 +413,14 @@
         # so noctalia can't write it in place).
         nushell.environmentVariables.STARSHIP_CONFIG = "${config.home.homeDirectory}/.cache/starship.toml";
 
-        # bat: select the noctalia theme rendered by the user template below.
-        # Selecting via HM's option (a declarative `--theme=noctalia` in bat's
-        # config) applies to every shell, not just nushell — and HM legitimately
-        # owns that config file, so this isn't the in-place apply.sh rewrite we
-        # avoid. bat is spawned fresh per invocation, so it picks up each cache
-        # rebuild with no reload.
+        # bat: via HM's option rather than nushell's alias, so every shell gets it —
+        # and HM owns that config file, so this isn't the in-place apply.sh rewrite we
+        # avoid elsewhere. bat is spawned fresh per invocation, so no reload hook.
         bat.config.theme = "noctalia";
 
-        # Claude Code: select the noctalia custom theme rendered by the user
-        # template below. Set here (niri aspect) rather than in
-        # modules/claude/claude.nix so it only applies on hosts that actually run
-        # noctalia to render the theme file; merges into the settings from
-        # claude.nix. "custom:<slug>" is Claude Code's selector for
-        # $CLAUDE_CONFIG_DIR/themes/<slug>.json.
+        # Claude Code: "custom:<slug>" selects $CLAUDE_CONFIG_DIR/themes/<slug>.json.
+        # Set here rather than in modules/claude/claude.nix (into whose settings it
+        # merges) so it only lands on hosts that run noctalia to render that file.
         claude-code.settings.theme = "custom:noctalia";
 
         noctalia = {
@@ -355,12 +441,12 @@
               source = "custom";
               custom_palette = "gruvbox-material";
 
-              # Render side theme files from the palette; the links/includes above
-              # make each app pick them up. Everything else stays stylix.
+              # The links/includes above are what make each app pick these up.
+              # Everything not listed here stays stylix's.
               templates = {
                 enable_builtin_templates = true;
                 builtin_ids = [
-                  "foot"
+                  # No "foot": the `foot` user template below replaces it.
                   "helix"
                   "niri"
                   # GTK colors only — GTK apps (Nautilus, file-picker dialogs) follow
@@ -375,6 +461,16 @@
                 # Each template's render logic + reasoning is on its `let` binding
                 # above; comments here note only per-app render hooks.
                 user = {
+                  # post_hook signals the foot *server*, which switches every current
+                  # and future client window: SIGUSR1 = [colors-dark], SIGUSR2 =
+                  # [colors-light]. `-x` skips the footclient processes (the server
+                  # covers their windows); `|| true` tolerates no server yet.
+                  foot = {
+                    enabled = true;
+                    input_path = "${footThemeTemplate}";
+                    output_path = footThemeFile;
+                    post_hook = ''if [ "{{ mode }}" = light ]; then ${pkgs.procps}/bin/pkill -USR2 -x foot; else ${pkgs.procps}/bin/pkill -USR1 -x foot; fi || true'';
+                  };
                   terminal-sequences = {
                     enabled = true;
                     input_path = "${terminalSequences}";

--- a/modules/niri/noctalia.nix
+++ b/modules/niri/noctalia.nix
@@ -536,8 +536,10 @@
             };
 
             shell = {
-              # nerd font for the bar's glyphs/icons
-              font_family = lib.mkDefault "IosevkaTerm Nerd Font";
+              # Bar/launcher/panel *text* only — the icons come from noctalia's own
+              # bundled tabler.ttf, so no nerd-font coverage is needed here. Inheriting
+              # stylix's sans keeps the shell on the same font as the GTK apps.
+              font_family = lib.mkDefault config.stylix.fonts.sansSerif.name;
             };
 
             # External-monitor brightness over DDC/CI (gated off by default in

--- a/modules/niri/noctalia.nix
+++ b/modules/niri/noctalia.nix
@@ -568,9 +568,18 @@
               temperature_night = 4000;
             };
 
+            # Blurred/tinted copy of the wallpaper on its own background surface
+            # (namespace noctalia-backdrop), which ./niri.nix's layer-rule places in
+            # niri's overview backdrop. Off by default in noctalia, and the layer-rule
+            # matches nothing without it. blur/tint are 0..1.
+            backdrop = {
+              enabled = true;
+              blur_intensity = 0.5;
+              tint_intensity = 0.3;
+            };
+
             wallpaper = {
-              # A folder so more can be added later; seeded with the stylix image
-              # via xdg.configFile above.
+              # Seeded with the stylix image via xdg.configFile above.
               directory = "${config.xdg.configHome}/noctalia/wallpapers";
 
               # Rotate randomly (off by default; interval_seconds keeps its 30-min

--- a/modules/niri/noctalia.nix
+++ b/modules/niri/noctalia.nix
@@ -365,8 +365,16 @@
 
         # Import noctalia's rendered gtk css (see the gtk3/gtk4 builtin_ids below).
         # Declared via stylix's extraCss so apply.sh finds it present and won't
-        # rewrite the read-only gtk.css symlink.
-        gtk.extraCss = ''@import url("noctalia.css");'';
+        # rewrite the read-only gtk.css symlink. The import is relative, so it only
+        # resolves next to the file noctalia renders — hence flatpakSupport off: it
+        # appends this same css to a flattened adw-gtk3 copy under ~/.themes, where
+        # there is no noctalia.css (nor any way to add one, the dir being a store
+        # path), and every GTK app loading that theme logs a parse error. Nothing
+        # here uses Flatpak, which is all that copy is for.
+        gtk = {
+          extraCss = ''@import url("noctalia.css");'';
+          flatpakSupport.enable = false;
+        };
       };
 
       # Seed noctalia's wallpaper folder with the stylix image. Drop more images

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -1,12 +1,20 @@
 { ... }:
 {
   nixos.modules.desktop =
-    { pkgs, ... }:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
     {
       services = {
         openssh.enable = true;
         printing.enable = true;
         fwupd.enable = true;
+        # Smartcard access for gpg's scdaemon (modules/gpg.nix sets disable-ccid, so
+        # it goes through pcscd rather than claiming the yubikey itself, leaving the
+        # card usable by ykman and age-plugin-yubikey).
         pcscd.enable = true;
         btrfs.autoScrub.enable = true;
         avahi.nssmdns4 = true;
@@ -18,6 +26,21 @@
           ];
         };
       };
+
+      # Drop the `-x` (--auto-exit) the nixpkgs module hardcodes: pcscd quits after
+      # 60 s idle, and taking the reader down powers off the card, so the yubikey's
+      # OpenPGP applet loses its verified PIN. With the signature PIN *not* forced on
+      # the card, a PIN entry should otherwise cover every later signature — instead
+      # each commit a minute apart asked again. /etc/reader.conf is the same file the
+      # module points at.
+      # mkForce, not a plain list: these merge, and the winner would then depend on
+      # definition order. The leading "" resets the vendor unit's ExecStart.
+      systemd.services.pcscd.serviceConfig.ExecStart = lib.mkForce [
+        ""
+        "${
+          lib.getExe (if config.security.polkit.enable then pkgs.pcscliteWithPolkit else pkgs.pcsclite)
+        } -f -c /etc/reader.conf"
+      ];
 
       xdg.portal = {
         enable = true;

--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -29,6 +29,14 @@
         Unit = {
           Description = "SSH authentication agent";
           PartOf = [ "graphical-session.target" ];
+          # The yubikey keys are verify-required, so the *agent* pops the FIDO PIN
+          # prompt (SSH_ASKPASS below) on every signature. Without this ordering it
+          # can start before the compositor has published WAYLAND_DISPLAY/DISPLAY into
+          # the systemd user environment, and a service only ever sees the environment
+          # it was exec'd with — leaving askpass blind for the whole session:
+          # `ssh-askpass: cannot open display` → the agent reads the empty reply as a
+          # wrong PIN → `agent refused operation`.
+          After = [ "graphical-session.target" ];
         };
         Service = {
           ExecStart = "${pkgs.openssh}/bin/ssh-agent -D -a %t/ssh-agent";


### PR DESCRIPTION
- **fix(niri): keep foot and zellij on the live noctalia palette**
- **feat(desktop): use Inter as the UI sans**
- **feat(niri): skip noctalia's setup wizard, enable overview type-to-launch**
- **fix(desktop): disable the unused ibus input method**
- **feat(niri): follow noctalia's recommended niri settings**
- **feat(niri): lid handling for laptops, hot corners; tighten comments**
