### PR TITLE
fix(just): allocate a tty for upgrade-now

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,9 +45,10 @@ deploy host=srv target=(host + ".local"):
 deploy-boot host=srv target=(host + ".local"):
     nh os boot --target-host {{ target }} --hostname {{ host }} .
 
+# -t because sudo needs a terminal to prompt and ssh only allocates one on request
 # Run the server's pull-based upgrade now instead of waiting for tonight's timer
 upgrade-now host=srv target=(host + ".local"):
-    ssh {{ target }} sudo systemctl start nixos-upgrade.service
+    ssh -t {{ target }} sudo systemctl start nixos-upgrade.service
 
 # Show the last pull-based upgrades — spans two nights, so a skipped run shows as an absence
 upgrade-log host=srv target=(host + ".local"):


### PR DESCRIPTION
`nixos-upgrade.service` is started through sudo on the remote host, and sudo
needs a terminal to prompt for a password — ssh only allocates one when asked.
Without -t the recipe failed on the password prompt.

The rationale sits above the description rather than below it: just takes the
comment line immediately preceding a recipe as its `just --list` description, so
a second line underneath would replace it.
