### PR TITLE
feat(srv-01): run Home Assistant as a libvirt guest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia, Homepage, Restic; LUKS unlocked from the TPM (PCR 7)
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia, Homepage, Restic, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7)
 
 ### Module Organization
 
@@ -172,7 +172,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `restic`, `calibre`, `printing`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `restic`, `calibre`, `printing`, `homeAssistant`)
 
 Most features are flat `modules/<feature>.nix` files; directories appear only for a cohesive multi-file capability (`desktop/`) or a peer-set (`machines/`, `server/`, `shells/`). Per-user config goes through `homeManager.modules.base` (every host) / `homeManager.modules.gui` (desktop) inside the owning feature file — never `home-manager.users.*` directly (except the wiring in `users.nix`).
 
@@ -207,6 +207,7 @@ Major flake inputs:
 - `lanzaboote`: Secure Boot support
 - `sops-nix`: Secret management
 - `nixos-hardware`: Hardware-specific configurations
+- `nixvirt`: Declarative libvirt domains (srv-01's Home Assistant guest)
 
 ## Development Workflow
 
@@ -291,7 +292,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `restic`, `calibre`, `printing`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `restic`, `calibre`, `printing`, `homeAssistant`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/flake.lock
+++ b/flake.lock
@@ -420,6 +420,26 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
+    "nixvirt": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783240168,
+        "narHash": "sha256-9zaLOKal8uI+ecKaOBCOfGcZe/HG1xQQnlDDjPoOmwE=",
+        "owner": "AshleyYakeley",
+        "repo": "NixVirt",
+        "rev": "6d213ab42f72ba41c2eb4e6bdb97581c0642d942",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AshleyYakeley",
+        "repo": "NixVirt",
+        "type": "github"
+      }
+    },
     "noctalia": {
       "inputs": {
         "nixpkgs": "nixpkgs_4"
@@ -512,6 +532,7 @@
         "niri": "niri",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
+        "nixvirt": "nixvirt",
         "noctalia": "noctalia",
         "noctalia-greeter": "noctalia-greeter",
         "preservation": "preservation",

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,20 @@
     # Hardware
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
 
+    # Virtualisation
+    #
+    # Declarative libvirt objects (srv-01's Home Assistant guest). The branch,
+    # not the v0.6.0 tag (May 2025, and no newer one): that tag predates the
+    # hostdev `startupPolicy` and graphics `port` attributes used here, and its
+    # XML generator drops unknown attributes *silently* rather than failing, so
+    # pinning it yields a domain quietly missing them. `follows` matters more
+    # than lock hygiene here — NixVirt imports its nixpkgs directly to build the
+    # libvirt it hands to the module.
+    nixvirt = {
+      url = "github:AshleyYakeley/NixVirt";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Desktop & theming
     arkenfox-nix = {
       url = "github:HeitorAugustoLN/arkenfox-nix";

--- a/modules/_hosts/srv-01/hardware.nix
+++ b/modules/_hosts/srv-01/hardware.nix
@@ -11,7 +11,12 @@
   };
 
   networking = {
-    interfaces.lan0.ipv4.addresses = [
+    # The host's address sits on a bridge rather than on lan0 directly so the
+    # Home Assistant guest (see ../../server/home-assistant.nix) can be a peer on
+    # the LAN: it needs L2 access for mDNS/SSDP discovery and for the inbound
+    # callbacks half its integrations rely on, neither of which survives NAT.
+    bridges.br0.interfaces = [ "lan0" ];
+    interfaces.br0.ipv4.addresses = [
       {
         address = "10.0.0.57";
         prefixLength = 24;

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -14,6 +14,7 @@
         restic
         calibre
         printing
+        homeAssistant
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/server/home-assistant.nix
+++ b/modules/server/home-assistant.nix
@@ -1,0 +1,211 @@
+{ inputs, ... }:
+let
+  # `vmAddress` is a DHCP reservation for `macAddress` on the router rather than
+  # static config inside the guest: dnsmasq then registers the name, and a
+  # reseeded guest lands on the right address untouched — HAOS keeps its network
+  # settings in the OS layer, which an HA backup does not restore. Keep the
+  # address out of the dynamic pool.
+  vmAddress = "10.0.0.52";
+  macAddress = "02:81:fd:53:ce:51";
+
+  diskImage = "/var/lib/libvirt/images/haos.qcow2";
+in
+{
+  # Home Assistant OS as a libvirt guest. HAOS rather than nixpkgs'
+  # `services.home-assistant` because only a full HAOS install carries the
+  # supervisor, and only the supervisor can restore the backups from the Proxmox
+  # instance this replaces.
+  nixos.modules.homeAssistant =
+    {
+      pkgs,
+      mkRouter,
+      ...
+    }:
+    let
+      nixvirt = inputs.nixvirt.lib;
+
+      base = nixvirt.domain.templates.linux {
+        name = "haos";
+        uuid = "987480bd-0c79-458d-9310-bec4804b6f74";
+        vcpu.count = 2;
+        memory = {
+          count = 4;
+          unit = "GiB";
+        };
+        storage_vol = diskImage;
+        # Defined in ../_hosts/srv-01/hardware.nix, which explains why it exists.
+        bridge_name = "br0";
+        net_iface_mac = macAddress;
+        # A virtio model with accel3d would want a GL-backed display; this guest
+        # only ever gets looked at over VNC, so take the qxl model instead.
+        virtio_video = false;
+      };
+
+      domain = base // {
+        os = base.os // {
+          # Nothing to boot off the empty cdrom the template also adds.
+          boot = [ { dev = "hd"; } ];
+          # HAOS x86-64 boots UEFI only, and wants a firmware built without
+          # secure boot — `pkgs.OVMF` is exactly that (`OVMFFull` carries the SB
+          # variants). libvirt copies the VARS template into the nvram path on
+          # first start, which is why /var/lib/libvirt is preserved below.
+          loader = {
+            readonly = true;
+            type = "pflash";
+            path = pkgs.OVMF.fd.firmware;
+          };
+          nvram = {
+            template = pkgs.OVMF.fd.variables;
+            path = "/var/lib/libvirt/qemu/nvram/haos_VARS.fd";
+          };
+        };
+
+        devices = base.devices // {
+          # The template reaches for full `qemu`, ~570 MB of which is emulators
+          # for architectures this host will never run.
+          emulator = "${pkgs.qemu_kvm}/bin/qemu-system-x86_64";
+
+          # 10c4:ea60 — the SkyConnect Zigbee radio — in *decimal*, because Nix
+          # has no hex literals and NixVirt renders ints with toString. Re-derive
+          # after a dongle swap with `printf '%d %d\n' 0x10c4 0xea60`; libvirt
+          # normalises them back, so `virsh dumpxml haos` is the check.
+          hostdev = [
+            {
+              mode = "subsystem";
+              type = "usb";
+              managed = true;
+              source = {
+                # Without this the guest refuses to start whenever the dongle is
+                # absent, a poor trade for a house's automation. The flip side is
+                # that libvirt won't hot-add it either: a dongle plugged in after
+                # the guest booted needs a restart to be picked up.
+                startupPolicy = "optional";
+                vendor.id = 4292;
+                product.id = 60000;
+              };
+            }
+          ];
+
+          # The template targets a SPICE desktop; a headless server wants a
+          # console it can reach over SSH instead. `virsh console haos` for the
+          # serial one, or tunnel 5900 for the framebuffer.
+          graphics = {
+            type = "vnc";
+            port = 5900;
+            autoport = false;
+            listen = {
+              type = "address";
+              address = "127.0.0.1";
+            };
+          };
+          serial = {
+            type = "pty";
+          };
+          console = {
+            type = "pty";
+            target.type = "serial";
+          };
+          sound = null;
+          audio = null;
+          redirdev = null;
+          # Keep the qemu guest agent (libvirt shuts the guest down through it),
+          # drop the spicevmc channel that went with SPICE.
+          channel = [
+            {
+              type = "unix";
+              target = {
+                type = "virtio";
+                name = "org.qemu.guest_agent.0";
+              };
+            }
+          ];
+        };
+      };
+    in
+    {
+      imports = [ inputs.nixvirt.nixosModules.default ];
+
+      virtualisation = {
+        libvirt = {
+          enable = true;
+          # NixVirt would otherwise reach into its own nixpkgs for libvirt.
+          package = pkgs.libvirt;
+          connections."qemu:///system".domains = [
+            {
+              definition = nixvirt.domain.writeXML domain;
+              active = true;
+              # Never restart the guest on activation. `autoUpgrade` rebuilds
+              # this host nightly at 03:00, and a definition diff — a bumped OVMF
+              # store path, say — would otherwise take the heating and the lights
+              # down with it. Definition changes land in the persistent config
+              # and apply at the next deliberate restart.
+              restart = false;
+            }
+          ];
+        };
+        libvirtd = {
+          # Match the emulator picked above; libvirtd otherwise stages the full
+          # qemu into /run/libvirt/nix-emulators and onto the system path.
+          qemu.package = pkgs.qemu_kvm;
+          # Default is "suspend", which restores a guest with a stale clock and a
+          # stale view of its Zigbee dongle. ACPI shutdown instead, so the
+          # nightly kernel reboot stops HAOS cleanly.
+          onShutdown = "shutdown";
+        };
+      };
+
+      # Seeds a fresh HAOS install once and then leaves it alone — HAOS updates
+      # itself in place, so this pin only ever matters for a bare-metal rebuild
+      # of srv-01. It costs ~550 MB of store space to keep that reproducible.
+      systemd.services.haos-image =
+        let
+          # The `ova` artifact, *not* `generic-x86-64`: the generic one is the
+          # bare-metal image, and HAOS detects it running under virtualization
+          # and marks the install unsupported (`virtualization_image`). The OVA
+          # image is the KVM one — para-virt drivers and guest tools included.
+          image = pkgs.fetchurl {
+            url = "https://github.com/home-assistant/operating-system/releases/download/18.2/haos_ova-18.2.qcow2.xz";
+            hash = "sha256-JU5T81TfBznjr8Cb5UMaB99T8N9rcDiFQE9mXEVPJU4=";
+          };
+        in
+        {
+          description = "Seed the Home Assistant OS disk image";
+          requiredBy = [ "nixvirt.service" ];
+          before = [ "nixvirt.service" ];
+          unitConfig.ConditionPathExists = "!${diskImage}";
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          path = [ pkgs.xz ];
+          # Written under a temporary name so an interrupted seed cannot leave a
+          # half-written image that the condition above would then treat as done.
+          # No resize: the artifact is already a qcow2 with a 32 GB virtual size,
+          # which HAOS grows its data partition into on first boot.
+          script = ''
+            mkdir -p "$(dirname ${diskImage})"
+            xz -dc ${image} > ${diskImage}.tmp
+            chmod 0600 ${diskImage}.tmp
+            mv ${diskImage}.tmp ${diskImage}
+          '';
+        };
+
+      preservation.preserveAt."/persistent".directories = [ "/var/lib/libvirt" ];
+
+      # Deliberately not `mkAutheliaRouter`: Home Assistant authenticates its own
+      # users, and a forward-auth in front of it breaks the companion app,
+      # webhooks and every long-lived-token API client — none of which can follow
+      # an interactive SSO redirect. Traefik is here for TLS and one certificate
+      # story, not for authentication.
+      #
+      # HA rejects proxied requests unless it is told to trust this hop, so the
+      # guest's configuration.yaml needs:
+      #     http:
+      #       use_x_forwarded_for: true
+      #       trusted_proxies: [ 10.0.0.57 ]
+      services.traefik.dynamicConfigOptions.http = mkRouter {
+        name = "homeassistant";
+        url = "http://${vmAddress}:8123";
+      };
+    };
+}

--- a/modules/server/homepage.nix
+++ b/modules/server/homepage.nix
@@ -66,8 +66,6 @@
                     href = "https://homeassistant.${constants.domain}/";
                     siteMonitor = "https://homeassistant.${constants.domain}/";
                     description = "Home automation";
-                    proxmoxNode = "proxmox1";
-                    proxmoxVMID = 100;
                     widget = {
                       type = "homeassistant";
                       url = "https://homeassistant.${constants.domain}";

--- a/modules/server/traefik-router.nix
+++ b/modules/server/traefik-router.nix
@@ -1,28 +1,35 @@
 { ... }:
 {
-  # Inject `mkAutheliaRouter` as a module arg for server aspects: builds the
-  # repeated Traefik `http` block (an authelia-protected router + its
-  # loadBalancer service) from a service name + local port. Closes over
-  # `constants.domain` so subdomains stay in sync with the shared domain.
+  # Inject the Traefik `http` block builders as module args for server aspects:
+  # a router plus its loadBalancer service, from a name and a backend. Closes
+  # over `constants.domain` so subdomains stay in sync with the shared domain.
+  # `mkAutheliaRouter` is the common case — everything on this host sits behind
+  # SSO except Home Assistant, which authenticates its own clients.
   nixos.modules.server =
-    { constants, ... }:
-    {
-      _module.args.mkAutheliaRouter =
+    { constants, lib, ... }:
+    let
+      mkRouter =
         {
           name,
-          port,
+          port ? null,
+          url ? "http://localhost:${toString port}",
           subdomain ? name,
+          middlewares ? [ ],
         }:
         {
           routers.${name} = {
             rule = "Host(`${subdomain}.${constants.domain}`)";
             entrypoints = [ "websecure" ];
-            middlewares = [ "authelia" ];
             service = name;
-          };
-          services.${name}.loadBalancer.servers = [
-            { url = "http://localhost:${toString port}"; }
-          ];
+          }
+          // lib.optionalAttrs (middlewares != [ ]) { inherit middlewares; };
+          services.${name}.loadBalancer.servers = [ { inherit url; } ];
         };
+    in
+    {
+      _module.args = {
+        inherit mkRouter;
+        mkAutheliaRouter = args: mkRouter (args // { middlewares = [ "authelia" ]; });
+      };
     };
 }


### PR DESCRIPTION
Migrates Home Assistant off the Proxmox node onto srv-01 as an HAOS guest
under libvirt, declared with NixVirt. HAOS rather than nixpkgs'
`services.home-assistant`: only a full HAOS install carries the
supervisor, and only the supervisor can restore the existing backups.

The guest is bridged onto the LAN (lan0 -> br0) rather than NAT'd. Home
Assistant needs L2 access for mDNS/SSDP discovery and for the inbound
event callbacks a good half of its integrations rely on, neither of which
survives NAT. It carries the old Proxmox VM's MAC so it inherits that
DHCP reservation, and every integration pinned to HA's address keeps
working.

The SkyConnect Zigbee radio is passed through by USB vendor/product with
startupPolicy=optional, so the guest still boots when the dongle is out.

Traefik fronts it with a plain router — deliberately not Authelia, which
would break the companion app, webhooks and long-lived-token API clients.
That generalises mkAutheliaRouter into mkRouter, keeping the authelia
variant as a thin wrapper over it.

A oneshot seeds the disk once from a pinned HAOS image, so a bare-metal
rebuild of srv-01 reproduces a bootable guest; HAOS updates itself in
place afterwards. The `ova` artifact, not `generic-x86-64` — the latter
is the bare-metal image, which HAOS flags unsupported under
virtualisation.

Restoring the backup itself stays a manual step through the HA onboarding
UI, as does setting use_x_forwarded_for/trusted_proxies in the guest.
