### PR TITLE
feat(traefik): serve every route from one wildcard certificate

### DIFF
--- a/modules/server/lldap.nix
+++ b/modules/server/lldap.nix
@@ -75,7 +75,17 @@
                 rule = "HostSNI(`ldap.${constants.domain}`)";
                 entrypoints = [ "ldapsecure" ];
                 service = "lldap-backend";
-                tls.certResolver = "cloudflareDns";
+                # `ldapsecure` has no `http` block to inherit entrypoint TLS
+                # from, so this router repeats the wildcard itself.
+                tls = {
+                  certResolver = "cloudflareDns";
+                  domains = [
+                    {
+                      main = constants.domain;
+                      sans = [ "*.${constants.domain}" ];
+                    }
+                  ];
+                };
               };
               services.lldap-backend.loadBalancer.servers = [ { address = "127.0.0.1:3890"; } ];
             };

--- a/modules/server/traefik.nix
+++ b/modules/server/traefik.nix
@@ -29,7 +29,19 @@
             };
             websecure = {
               address = ":443";
-              http.tls.certResolver = "cloudflareDns";
+              http.tls = {
+                certResolver = "cloudflareDns";
+                # One wildcard instead of the per-router certificate Traefik
+                # otherwise infers from each `Host()` rule, so no subdomain
+                # reaches the CT logs. `*.` covers one label and never the
+                # apex, hence the apex as `main` and the wildcard as a SAN.
+                domains = [
+                  {
+                    main = constants.domain;
+                    sans = [ "*.${constants.domain}" ];
+                  }
+                ];
+              };
             };
             ldapsecure = {
               address = ":636";
@@ -66,7 +78,7 @@
               resolver = "cloudflareDns";
               domain = {
                 main = constants.domain;
-                sans = [ "lldap.${constants.domain}" ];
+                sans = [ "*.${constants.domain}" ];
               };
             };
           };


### PR DESCRIPTION
Traefik inferred a certificate per proxied hostname from each router's
`Host()` rule — six ACME orders, six renewals, and six internal
hostnames published to the Certificate Transparency logs.

Name the domains on the `websecure` entrypoint instead, so every router
on it shares a single `home.guimbert.fr` + `*.home.guimbert.fr` cert;
`mkRouter` emits no `tls` block, so future services inherit it for free.
The LLDAP TCP router repeats the pair, `ldapsecure` having no `http`
block to inherit from, and the default generated cert follows suit
(dropping its stale `lldap.` SAN, a name no router ever used).
