### PR TITLE
feat(srv-01): serve the media library with Jellyfin and the *arr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,9 @@ Three ways in, because apps fall into three groups:
 - **LDAP** (`modules/server/lldap.nix`) — for apps that speak neither. Kept **deliberately**: the
   Jellyfin OIDC plugin (`9p4/jellyfin-plugin-sso`) was archived upstream in May 2026 with no
   successor fork, and never completed the flow outside a browser anyway, so LDAP is the only
-  credential its TV and mobile clients can use. Nothing else off-host currently binds `:636`;
-  do not remove LLDAP on that basis alone.
+  credential its TV and mobile clients can use. That is now a live dependency rather than a
+  hypothetical one — see "Media on srv-01". Nothing else off-host currently binds `:636`; do not
+  remove LLDAP on that basis alone.
 
 Passkeys are enabled (`webauthn.enable_passkey_login`). Authelia 4.39 counts a passkey as *one*
 factor, so it opens the `one_factor` forward-auth routes on its own, but not an OIDC client set
@@ -118,9 +119,11 @@ hand the plaintext to the app. Authelia refuses to start with an empty client li
 
 ### Backing up srv-01
 
-srv-01 pushes nothing. The `backup` aspect (`modules/server/backup.nix`) stages the lldap and
-authelia state into `/var/backup/data` at 01:00, and the TrueNAS *pulls* it over SFTP, so
-srv-01 holds no credential that reaches its own backups. Retention is the NAS's periodic
+srv-01 pushes nothing. The `backup` aspect (`modules/server/backup.nix`) stages the lldap,
+authelia, *arr and Jellyfin state into `/var/backup/data` at 01:00, and the TrueNAS *pulls* it
+over SFTP, so srv-01 holds no credential that reaches its own backups. The media is never in
+scope — it lives on the NAS to begin with — and neither is Jellyfin's metadata cache, which is
+artwork it re-fetches on demand. Retention is the NAS's periodic
 snapshot task, not anything here, and `/var/lib/traefik` is deliberately out of scope —
 `acme.json` holds the wildcard cert's private key, which Cloudflare DNS re-issues for free.
 Restores are in README.md.
@@ -168,6 +171,46 @@ removes, and which TrueNAS raises a daily alert for using at all; its WebSocket 
 needs a login round trip before the query, which a Gatus websocket endpoint cannot do. And
 **a whole-house power or ISP outage** silences both machines — closing that needs an outbound
 heartbeat to something off-site.
+
+### Media on srv-01
+
+Three aspects, split along the lines that actually differ:
+
+- **`mediaLibrary`** (`modules/server/media-library.nix`) — the storage, declared once and read by
+  the other two. The bytes live on the NAS (`main/media/video`, sibling of the `books` dataset
+  Calibre-web uses) and reach srv-01 over **NFS**, via a `_lib/nfs.nix` builder mirroring the CIFS
+  one. NFS rather than CIFS because three services share the tree: CIFS fakes ownership with one
+  mount identity for all of them, where NFS carries real uid/gid and does hardlinks and atomic
+  renames — what the *arr do on every import, and what a downloader would need later.
+- **`jellyfin`** (`modules/server/jellyfin.nix`) — transcoding runs here and not on the NAS
+  *because of the silicon*: srv-01's i5-9500T has a UHD 630 that decodes HEVC 10-bit and tone-maps
+  HDR→SDR in fixed-function hardware, against the NAS's Celeron J4125. VAAPI rather than QSV (on
+  Gen9.5 the QSV path wants the legacy libmfx runtime for no gain), and `forceEncodingConfig`
+  makes `encoding.xml` config-as-code — the dashboard's transcoding page is overwritten on every
+  restart, deliberately.
+- **`servarr`** (`modules/server/servarr.nix`) — Sonarr, Radarr and Prowlarr as one aspect
+  driven by a table, since they differ only in name, port and tile. No downloader: imports are
+  manual, so these organise and rename rather than fetch.
+
+Two things are easy to get wrong here:
+
+- **Jellyfin is the one route with no Authelia middleware** (`mkRouter`, not `mkAutheliaRouter`).
+  A TV or phone client cannot complete a browser SSO round trip, so Jellyfin authenticates them
+  itself against LLDAP — that is what LLDAP is *for*. The *arr, browser-only admin UIs, sit behind
+  the middleware and delegate to it entirely (`auth.method = "External"`). Do not "harden" that
+  back to `"Forms"`: these apps only offer the screen that creates their first user while no
+  method is configured, so setting one before first run leaves a login page, an empty user table
+  and no way in.
+- **`UMask = "0002"` on Sonarr and Radarr is load-bearing**, and forced over the modules' 0022.
+  The NAS dataset carries a POSIX default ACL granting the `media` group write, but a default
+  ACL's effective permission is capped by the mask the creation mode implies: a directory created
+  under 0022 lands group `r-x`, and the next writer — a manual copy over SMB from a desktop —
+  cannot write into it. The `media` gid (3006) is **read back from the NAS**, not chosen — TrueNAS
+  allocated it, and a number invented here would put the services in a group matching nothing. The
+  export maps every request to `media:media`, so client *uids* never have to line up.
+
+Prowlarr additionally runs with `DynamicUser` forced off, for the same reason lldap does: a uid
+allocated per boot cannot own preserved state.
 
 ### Formatting and Linting
 
@@ -249,7 +292,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Calibre-web, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Calibre-web, Jellyfin + the *arr over an NFS library from the NAS, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01"
 
 ### Module Organization
 
@@ -257,7 +300,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -270,12 +313,12 @@ each feature adds to it beside its own config:
   tiles for things that run off this host, the group order, and an assertion that no tile names a
   group outside it. Tiles are sorted by name within a group, since merge order follows module
   evaluation rather than intent.
-- `mkRouter` / `mkAutheliaRouter` (`modules/server/traefik-router.nix`) and `mkHeartbeat`
-  (`modules/server/gatus.nix`) are the same idea via `_module.args`: a builder defined once,
-  called by each feature.
+- `mkRouter` / `mkAutheliaRouter` (`modules/server/traefik-router.nix`), `mkHeartbeat`
+  (`modules/server/gatus.nix`) and `mediaLibrary` (`modules/server/media-library.nix`) are the
+  same idea via `_module.args`: a builder or a constant defined once, read by each feature.
 
-Both create a real dependency — an aspect using `homepageTiles` or `mkHeartbeat` will not evaluate
-on a host that omits `homepage` or `gatus`. That is deliberate: a loud eval failure beats a tile
+Both create a real dependency — an aspect using `homepageTiles`, `mkHeartbeat` or `mediaLibrary`
+will not evaluate on a host that omits `homepage`, `gatus` or `mediaLibrary`. That is deliberate: a loud eval failure beats a tile
 that renders nowhere or a job that reports to nothing.
 
 Most features are flat `modules/<feature>.nix` files; directories appear only for a cohesive multi-file capability (`desktop/`) or a peer-set (`machines/`, `server/`, `shells/`). Per-user config goes through `homeManager.modules.base` (every host) / `homeManager.modules.gui` (desktop) inside the owning feature file — never `home-manager.users.*` directly (except the wiring in `users.nix`).
@@ -396,7 +439,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -260,10 +260,9 @@ git-tracked files, `git add` any brand new module before deploying.
 ### Restoring srv-01
 
 srv-01 never pushes a backup. A timer stages its service state into `/var/backup/data` at
-01:00 — the lldap and authelia databases go through sqlite's online-backup API, so they are
-consistent rather than caught mid-write — and the TrueNAS pulls that over SFTP an hour later.
-History is the NAS's snapshot schedule, so pick a snapshot there and copy its contents to the
-host first.
+01:00 — every sqlite database goes through the online-backup API, so they are consistent rather
+than caught mid-write — and the TrueNAS pulls that over SFTP an hour later. History is the NAS's
+snapshot schedule, so pick a snapshot there and copy its contents to the host first.
 
 Then, on srv-01:
 
@@ -280,6 +279,24 @@ chmod 0700 /var/lib/authelia-main
 
 systemctl start lldap authelia-main
 ```
+
+The media services restore the same way — indexers, quality profiles, libraries and watch history,
+none of which is reproducible from a rebuild:
+
+```bash
+systemctl stop jellyfin sonarr radarr prowlarr
+
+for svc in jellyfin sonarr radarr prowlarr; do
+  rsync -a <pulled>/$svc/ /var/lib/$svc/
+  chown -R $svc:$svc /var/lib/$svc
+done
+
+systemctl start jellyfin sonarr radarr prowlarr
+```
+
+Jellyfin's artwork is deliberately not in the backup — it re-fetches it — so expect the libraries
+to look bare until the first metadata scan finishes. The media itself was never at risk: it lives
+on the NAS, and srv-01 only mounts it.
 
 The staged copy is read by a single unprivileged account, so ownership is flattened on the way
 out — hence the chown steps. Traefik is not in the backup and needs nothing: it re-issues the

--- a/modules/_hosts/_lib/nfs.nix
+++ b/modules/_hosts/_lib/nfs.nix
@@ -1,0 +1,31 @@
+# Builds an NFS `fileSystems.<mountpoint>` entry for a `nas.lan:<export>` mount.
+#
+# `_`-prefixed dir → skipped by import-tree; imported as a plain function by the
+# aspects that mount NAS exports. NFS rather than the CIFS sibling for the media
+# library: it carries real uid/gid instead of one faked mount identity shared by
+# every service, and hardlinks and atomic renames work — which is what the *arr
+# do on every import.
+{
+  export,
+  server ? "nas.lan",
+  extraOptions ? [ ],
+}:
+{
+  device = "${server}:${export}";
+  fsType = "nfs";
+  options = [
+    "nfsvers=4.2"
+    # Automounted and `noauto`, so a NAS that is slow to come up delays the
+    # first read rather than the boot. No `idle-timeout` (unlike ./cifs.nix):
+    # unmounting under a paused stream is pointless churn.
+    "x-systemd.automount"
+    "noauto"
+    # The default, affirmed: a NAS reboot then suspends a read until it answers
+    # rather than failing it, and a playback that stalls beats a library that
+    # reports itself empty and invites the *arr to re-import it.
+    "hard"
+    "noatime"
+    "x-systemd.mount-timeout=10s"
+  ]
+  ++ extraOptions;
+}

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -17,6 +17,9 @@
         homeAssistant
         gatus
         beszel
+        mediaLibrary
+        jellyfin
+        servarr
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/networking.nix
+++ b/modules/networking.nix
@@ -25,6 +25,9 @@
         "/mnt/documents" = mkCifs "documents" [ ];
         "/mnt/shared" = mkCifs "shared" [ ];
         "/mnt/books" = mkCifs "books" [ "nobrl" ];
+        # The library srv-01 mounts over NFS (server/media-library.nix). The
+        # *arr organise it; the files get there by being copied in from here.
+        "/mnt/video" = mkCifs "video" [ ];
       };
 
       environment.systemPackages = [ pkgs.cifs-utils ];

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -1,8 +1,9 @@
 { ... }:
 {
   # srv-01 backs nothing up itself: it stages a consistent copy of its service
-  # state and the TrueNAS *pulls* that over SFTP, so nothing here holds a
-  # credential that reaches the backups. Retention is the NAS's snapshot task;
+  # state — lldap, authelia, the *arr and jellyfin's config — and the TrueNAS
+  # *pulls* that over SFTP, so nothing here holds a credential that reaches the
+  # backups. The media itself is never in scope: it lives on the NAS already. Retention is the NAS's snapshot task;
   # restores are in ../../README.md.
   nixos.modules.backup =
     {
@@ -25,6 +26,30 @@
       # Read back rather than re-typed, so it cannot drift out of step with the
       # aspect that owns it and leave this dumping a path that no longer exists.
       autheliaDb = config.services.authelia.instances.main.settings.storage.local.path;
+      jellyfinDir = config.services.jellyfin.dataDir;
+
+      # Staged wholesale. Jellyfin is not in the list: most of its data dir is a
+      # metadata image cache, so it gets its own rsync with that excluded.
+      stateDirs = [
+        "/var/lib/lldap"
+        "/var/lib/authelia-main"
+        "/var/lib/sonarr"
+        "/var/lib/radarr"
+        "/var/lib/prowlarr"
+      ];
+
+      # Live sqlite databases: dumped rather than copied, and excluded from the
+      # rsyncs above for the same reason. All sit under /var/lib and the staging
+      # tree mirrors it, so the destinations are derived rather than restated.
+      dumps = [
+        "/var/lib/lldap/users.db"
+        autheliaDb
+        "${config.services.sonarr.dataDir}/sonarr.db"
+        "${config.services.radarr.dataDir}/radarr.db"
+        "${config.services.prowlarr.dataDir}/prowlarr.db"
+        "${jellyfinDir}/data/jellyfin.db"
+        "${jellyfinDir}/data/library.db"
+      ];
     in
     {
       users = {
@@ -84,19 +109,28 @@
             # Live sqlite files are excluded rather than copied — rsync would
             # catch them mid-write. Excluded files are not deleted from the
             # destination either, so the dumps below survive the next run.
-            for src in /var/lib/lldap /var/lib/authelia-main; do
+            for src in ${lib.concatStringsSep " " stateDirs}; do
               rsync -a --delete --chown=nas-backup:nas-backup \
                 --exclude='*.db' --exclude='*.db-*' \
                 --exclude='*.sqlite3' --exclude='*.sqlite3-*' \
                 "$src"/ ${stagingDir}/"$(basename "$src")"/
             done
 
+            # Most of jellyfin's data dir is artwork it re-fetches on demand.
+            # Worth pulling: the config, the plugins, and the two databases
+            # below — users, libraries and watch history.
+            rsync -a --delete --chown=nas-backup:nas-backup \
+              --exclude='metadata/' --exclude='transcodes/' --exclude='log/' \
+              --exclude='*.db' --exclude='*.db-*' \
+              ${jellyfinDir}/ ${stagingDir}/jellyfin/
+
             # .backup rather than a file copy: the online-backup API is the only
             # way to snapshot a database its service holds open.
-            sqlite3 /var/lib/lldap/users.db ".backup '${stagingDir}/lldap/users.db'"
-            sqlite3 ${autheliaDb} ".backup '${stagingDir}/authelia-main/db.sqlite3'"
-            chown nas-backup:nas-backup \
-              ${stagingDir}/lldap/users.db ${stagingDir}/authelia-main/db.sqlite3
+            for db in ${lib.concatStringsSep " " dumps}; do
+              dest=${stagingDir}/''${db#/var/lib/}
+              sqlite3 "$db" ".backup '$dest'"
+              chown nas-backup:nas-backup "$dest"
+            done
           '';
         };
 

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -188,6 +188,9 @@
               })
               (mkAutheliaHttps { name = "homepage"; })
               (mkAutheliaHttps { name = "calibre"; })
+              (mkAutheliaHttps { name = "sonarr"; })
+              (mkAutheliaHttps { name = "radarr"; })
+              (mkAutheliaHttps { name = "prowlarr"; })
               (mkAutheliaHttps {
                 name = "traefik";
                 path = "/dashboard/";
@@ -197,6 +200,13 @@
                 path = "/dashboard/";
               })
               (mkHttps { name = "homeassistant"; })
+              # Not behind the middleware — it authenticates its own clients —
+              # so this reaches Jellyfin itself, and `/health` answers it
+              # without a session.
+              (mkHttps {
+                name = "jellyfin";
+                path = "/health";
+              })
               (mkHttps { name = "immich"; })
               (mkHttps {
                 name = "garage";

--- a/modules/server/jellyfin.nix
+++ b/modules/server/jellyfin.nix
@@ -1,0 +1,124 @@
+{ ... }:
+{
+  nixos.modules.jellyfin =
+    {
+      config,
+      constants,
+      lib,
+      mediaLibrary,
+      mkRouter,
+      pkgs,
+      ...
+    }:
+    {
+      users = {
+        users.jellyfin = {
+          # Chosen, not recorded like the older aspects' ids: nixpkgs allocates
+          # jellyfin none, and preserved state under a dynamic id stops being
+          # readable across a rebuild (../preservation.nix). 350 is ./backup.nix.
+          uid = 352;
+          # `media` is the load-bearing one. `render`/`video` are belt-and-braces
+          # — udev leaves render nodes at 0666, and under the unit's
+          # `PrivateUsers` an unmapped supplementary group grants nothing anyway.
+          extraGroups = [
+            mediaLibrary.group
+            "render"
+            "video"
+          ];
+        };
+        groups.jellyfin.gid = 352;
+      };
+
+      homepageTiles.Services = [
+        {
+          Jellyfin = {
+            icon = "jellyfin.png";
+            href = "https://jellyfin.${constants.domain}";
+            siteMonitor = "https://jellyfin.${constants.domain}";
+            description = "Media server";
+          };
+        }
+      ];
+
+      # A headless host still needs the userspace driver stack for VAAPI. iHD
+      # covers the UHD 630 (Gen9.5); the compute runtime is OpenCL, which is
+      # what the HDR→SDR tone-mapping filter runs on — without it a 4K HDR file
+      # transcoded for a phone comes out grey.
+      hardware.graphics = {
+        enable = true;
+        extraPackages = with pkgs; [
+          intel-media-driver
+          intel-compute-runtime
+        ];
+      };
+
+      services = {
+        jellyfin = {
+          enable = true;
+          hardwareAcceleration = {
+            enable = true;
+            # VAAPI rather than QSV: on Gen9.5 the QSV path wants the legacy
+            # libmfx runtime, while VAAPI + iHD drives the same fixed-function
+            # blocks and is the trodden path in nixpkgs.
+            type = "vaapi";
+            device = "/dev/dri/renderD128";
+          };
+          # Makes encoding.xml config-as-code: the dashboard's transcoding page
+          # is overwritten on every restart (the module backs up what it
+          # replaces), so this file is the single source of truth for it.
+          forceEncodingConfig = true;
+          transcoding = {
+            enableHardwareEncoding = true;
+            hardwareEncodingCodecs.hevc = true;
+            hardwareDecodingCodecs = {
+              h264 = true;
+              hevc = true;
+              hevc10bit = true;
+              vp9 = true;
+              mpeg2 = true;
+              vc1 = true;
+            };
+          };
+        };
+
+        # `mkRouter`, not `mkAutheliaRouter`, and deliberately so: the TV and
+        # phone clients cannot complete a browser SSO round trip, so Jellyfin
+        # authenticates them itself against LLDAP. That is the reason LLDAP
+        # exists — ../../CLAUDE.md, "Authentication on srv-01".
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "jellyfin";
+          # Jellyfin's listen port lives in its own network.xml, so there is no
+          # option to read it back from.
+          port = 8096;
+        };
+      };
+
+      systemd.services.jellyfin = {
+        unitConfig.RequiresMountsFor = [ mediaLibrary.dir ];
+        # The module creates these with tmpfiles, which holds on a boot but races
+        # on the `switch` that first introduces the preserved dataDir: tmpfiles
+        # wins, writes them to the tmpfs root, and preservation's bind mount then
+        # hides them — leaving the module's own preStart to die copying
+        # encoding.xml into a config/ that is not there.
+        preStart = lib.mkBefore ''
+          mkdir -p ${config.services.jellyfin.configDir} ${config.services.jellyfin.logDir}
+        '';
+      };
+
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = config.services.jellyfin.dataDir;
+          inherit (config.services.jellyfin) user group;
+          mode = "0700";
+        }
+        {
+          # Preserved for where it lands, not for what it holds: `/` is a tmpfs
+          # and transcode segments go to <cacheDir>/transcodes, so left out a 4K
+          # transcode buffers into RAM.
+          directory = config.services.jellyfin.cacheDir;
+          inherit (config.services.jellyfin) user group;
+          mode = "0700";
+        }
+      ];
+    };
+}

--- a/modules/server/media-library.nix
+++ b/modules/server/media-library.nix
@@ -1,0 +1,32 @@
+{ ... }:
+{
+  # The library itself: one NFS export from the NAS, read by ./jellyfin.nix and
+  # written by ./servarr.nix, declared here so the two cannot drift apart on
+  # where it is mounted or which group reaches it. Why the bytes live on the NAS
+  # while the work happens here: ../../CLAUDE.md, "Media on srv-01".
+  nixos.modules.mediaLibrary =
+    { ... }:
+    let
+      dir = "/mnt/media";
+    in
+    {
+      # Read back from the NAS (`stat` a file the export created), not chosen —
+      # TrueNAS allocated 3006, not the 3000 its range starts at. It has to
+      # match: the export maps every request to media:media, so a number picked
+      # here would put jellyfin and the *arr in a group matching nothing.
+      users.groups.media.gid = 3006;
+
+      fileSystems.${dir} = import ../_hosts/_lib/nfs.nix {
+        export = "/mnt/main/media/video";
+      };
+
+      # Same `_module.args` idiom as ./traefik-router.nix and ./gatus.nix: one
+      # definition, consumed by the aspects that need it. An aspect reading this
+      # will not evaluate on a host that omits `mediaLibrary`, which is the loud
+      # failure rather than a service pointed at an empty directory.
+      _module.args.mediaLibrary = {
+        inherit dir;
+        group = "media";
+      };
+    };
+}

--- a/modules/server/servarr.nix
+++ b/modules/server/servarr.nix
@@ -1,0 +1,145 @@
+{ ... }:
+{
+  # Sonarr, Radarr and Prowlarr in one aspect: they are deployed together, share
+  # the library mount, the sops shape and the Authelia routers, and differ only
+  # in the table below. No downloader — imports are manual for now, so these are
+  # a renamer, a renamer and an indexer manager.
+  nixos.modules.servarr =
+    {
+      config,
+      constants,
+      lib,
+      mediaLibrary,
+      mkAutheliaRouter,
+      ...
+    }:
+    let
+      apps = {
+        sonarr = {
+          title = "Sonarr";
+          description = "TV series library";
+          writesLibrary = true;
+        };
+        radarr = {
+          title = "Radarr";
+          description = "Movie library";
+          writesLibrary = true;
+        };
+        prowlarr = {
+          title = "Prowlarr";
+          description = "Indexer manager";
+          writesLibrary = false;
+        };
+      };
+      names = lib.attrNames apps;
+      writers = lib.attrNames (lib.filterAttrs (_: app: app.writesLibrary) apps);
+    in
+    {
+      users = {
+        users =
+          lib.genAttrs writers (_: {
+            # So an import can write to the NFS mount. Their uids are static in
+            # nixpkgs' own ids.nix (274/275), so unlike jellyfin and prowlarr
+            # there is nothing here to pin.
+            extraGroups = [ mediaLibrary.group ];
+          })
+          // {
+            prowlarr = {
+              isSystemUser = true;
+              group = "prowlarr";
+              # Chosen, like jellyfin's — upstream runs prowlarr under
+              # DynamicUser, so nixpkgs allocates it no static id.
+              uid = 353;
+            };
+          };
+        groups.prowlarr.gid = 353;
+      };
+
+      homepageTiles.Services = lib.mapAttrsToList (name: app: {
+        ${app.title} = {
+          icon = "${name}.png";
+          href = "https://${name}.${constants.domain}";
+          siteMonitor = "https://${name}.${constants.domain}";
+          inherit (app) description;
+        };
+      }) apps;
+
+      # A single `<APP>__AUTH__APIKEY=…` line each — one file per app rather than
+      # a shared blob, so none of them can read another's key. From sops so the
+      # keys survive a restore instead of being regenerated behind Prowlarr's
+      # back.
+      sops.secrets = lib.mapAttrs' (
+        name: _: lib.nameValuePair "${name}Environment" { owner = name; }
+      ) apps;
+
+      services =
+        lib.genAttrs names (name: {
+          enable = true;
+          # Flat, and the same path preservation bind-mounts. Sonarr and radarr
+          # default to burying their config two levels down (.config/NzbDrone,
+          # .config/Radarr), where their tmpfiles rules create the intermediate
+          # directory as root inside a service-owned parent — which systemd then
+          # refuses to canonicalize ("unsafe path transition") on every later
+          # run. prowlarr's default is already this, so it changes only the two.
+          dataDir = "/var/lib/${name}";
+          settings = {
+            # Traefik is the only way in: bound to loopback, and `openFirewall`
+            # left at its default false.
+            server.bindaddress = "127.0.0.1";
+            # Delegated to the Authelia middleware in front, which is the
+            # stronger of the two anyway. `"Forms"` is a trap here: these apps
+            # only offer the screen that *creates* their first user while no
+            # method is configured, so setting one before first run leaves a
+            # login page and an empty user table, with no way in.
+            auth = {
+              method = "External";
+              required = "Enabled";
+            };
+          };
+          environmentFiles = [ config.sops.secrets."${name}Environment".path ];
+        })
+        // {
+          traefik.dynamicConfigOptions.http = lib.mkMerge (
+            map (
+              name:
+              mkAutheliaRouter {
+                inherit name;
+                inherit (config.services.${name}.settings.server) port;
+              }
+            ) names
+          );
+        };
+
+      systemd.services =
+        lib.genAttrs writers (_: {
+          unitConfig.RequiresMountsFor = [ mediaLibrary.dir ];
+          # mkForce because the modules set 0022, and 0002 is not cosmetic here: a
+          # POSIX default ACL is capped by the mask the creation mode implies, so
+          # a directory created under 0022 lands group `r-x` on the NAS and the
+          # next writer — a manual copy over SMB — cannot write into it.
+          serviceConfig.UMask = lib.mkForce "0002";
+        })
+        // {
+          prowlarr.serviceConfig = {
+            # Same reason as ./lldap.nix: DynamicUser allocates a uid per boot,
+            # and the next boot cannot read the state the last one wrote. Turning
+            # it off also moves the state out of /var/lib/private/prowlarr, which
+            # is where the ExecStart's `-data` bind-mount would otherwise point.
+            DynamicUser = lib.mkForce false;
+            User = "prowlarr";
+            Group = "prowlarr";
+            # The only one of the three whose state directory systemd still
+            # creates, so the only one that would fight the mode below.
+            StateDirectoryMode = "0700";
+          };
+        };
+
+      # Ownership spelled out for the same reason as ./traefik.nix.
+      preservation.preserveAt."/persistent".directories = map (name: {
+        directory = config.services.${name}.dataDir;
+        user = name;
+        group = name;
+        mode = "0700";
+      }) names;
+    };
+}

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -19,6 +19,9 @@ autheliaOidcImmichClientSecret: ENC[AES256_GCM,data:OW6+P3vE2bxecvoIT5CB6bfizd/m
 autheliaOidcImmichClientSecretDigest: ENC[AES256_GCM,data:sJyMQcIzN0foj1hJB3zEpkVHc4jueoRrreqHDc0spNV2mkzrdVP20tva3EWBBgzOHhFHvn+KpUP+8xEZ22QDOZ2ioK099sgSlW1AgmXkRkEdbSavYGDZ38yyFEN+8DWu5QyQ/A9FxeR9I9Q6J5R/Hi3EZxMbFrsMo2PdKpXuXKE///Q=,iv:aHIQPCqnyEY9AxrVfKWxNrY+piMzh53a6+840FJ3q7o=,tag:hsBhkMML/kM4tbNan0Vbdw==,type:str]
 gatusEnvironments: ENC[AES256_GCM,data:HgE5omCr5kxoYrRbMZnPLmRQsI6bNx+bbyQaGarR/FNXGuI9kmbB2enEpmLHNoX+rNpYXeciG/PazdMiLqPWyOsGtIsmIOZf/et0WPHeL3tfUuYvjyTexfTgoWMaCGdrMv3HlGrCL9OGGbKFBMvwxkReAzRORH1RYXHvklTWluq7ej9fQpOWihYRbKymXo4EsZpaAasCjoHO1u/ocCemuRuzbCn+jHl7e+H0V2oS6kQbCBCG4kQ3LEMWptQ=,iv:W8d8oAKXmKVQVmxwh17tfdcPsy7gtt7v9MS1aCs1Kk4=,tag:TCGuJZPxemCmA7/WsfaEng==,type:str]
 beszelAgentEnvironment: ENC[AES256_GCM,data:pmdc/qWTgvfEeOVVhwz9Bsk7NXWk90Eeg8svnsK21wwcp0+lR9PHZRLsQKTsKoocKa1Otmo1sWYaMiWjfuu6WwXRuuZoqyVyjhMZqS2FFa0lMIt5WZ8QL49d0EGCf8eYzllatojYNLctsILL+Z1y0CRlp9uz+RA1nqKyp9JndNlw/kKN,iv:lh7Bv8D9FvLEm4l6uKIoKeQckK+8I8lc8MNXxKoNMDc=,tag:VrC3jmMh8Z0YBnT5PQnOpA==,type:str]
+sonarrEnvironment: ENC[AES256_GCM,data:x/S8CZZ8VBezyZKNUq+ZUKqQ/Yg0m06WBXn/5RDgyNpgYQzWWugkZyZKCZjTPbI8uTcnGfw=,iv:NsVMXTaWR/ZzYioued/SRiv3JGqDpb8qaIBskQbMZCE=,tag:zshUj0yayPX2r4xiN3lIZQ==,type:str]
+radarrEnvironment: ENC[AES256_GCM,data:78OtTB96AjmJLQxrLqRcHf2AenNC5yqbR8JSeFOiwIVaBTnp1RVjdcCmwUi6KcbyZUevM4M=,iv:aKTOwBZYqJzJpapT0EbNgRSU1NM91cPERUg655IXqfs=,tag:hapGR78o7LQAhegutWsgoA==,type:str]
+prowlarrEnvironment: ENC[AES256_GCM,data:1LdydNmImO16R2ZeODIXqxzluiZlyLADC+cQMY2FwW0mWrB5YzZnoyO3zaQlNTE0TiwXSpZtwQ==,iv:mZ4vjoPwC3bqovunZb8oiyItXINheV2ozzNxEQjn+2E=,tag:G8OeJlVWK1ROBUp6QooM7g==,type:str]
 sops:
     age:
         - enc: |
@@ -30,8 +33,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-04T14:48:44Z"
-    mac: ENC[AES256_GCM,data:g1ADdD60BHOWNsvUCJ0qNszvZ3ee6AhOMUU/uFX57HwKYK86xb9MUYT5LB02NudPHixssxks0heXU/5KI0jcr8Aq20oSNvJFYilecp2j5yZPOjAm+5inbdTK3goysyk3pexe9tV+9rD9yiJJbM9J4YYLFATITnktI1QOCJJf7F4=,iv:x+GnMmlwB3LlS+/VzXU6oVKRTBaAw9sURfpsCr8lpEg=,tag:/IAhvWcxlIHpFdzTx485iA==,type:str]
+    lastmodified: "2026-08-04T16:18:11Z"
+    mac: ENC[AES256_GCM,data:0KBiteYuWyvQv02IWih+7kW58kmGYBYVSKiCy9bM/qEOwScw7PeOgRhkE0JsjdZ1MNbhjAJAogSVjhv76ef5ThH9K/G1bshu+v3Ha6z+bt0Lhr0p+n+hzuVCt8rVR3qlIlB96BLkxBP0ANySZIvfXcPT0AzwSBs5ABGJRGHARH0=,iv:CQ7LcTNtRz3Ti9UyoucS9L/PWzjYtoV92KcIAjNLBlY=,tag:F6qxs4JQvIi356al2WLmRQ==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
There was no media server anywhere on the network — CLAUDE.md already named
Jellyfin as the reason LLDAP is kept, for a Jellyfin that did not exist.

Three aspects, split where the reasoning differs. mediaLibrary holds the
storage: the bytes stay on the NAS (main/media/video, sibling of the books
dataset) and reach this host over NFS rather than CIFS, because three services
share the tree and CIFS would give them one faked mount identity between them,
without working hardlinks or atomic renames — which is what an *arr import is.

jellyfin transcodes here rather than on the NAS because of the silicon: the
i5-9500T's UHD 630 decodes HEVC 10-bit and tone-maps HDR in fixed-function
hardware, against the NAS's Celeron. VAAPI rather than QSV, which on Gen9.5
wants the legacy libmfx runtime for no gain, and forceEncodingConfig makes
encoding.xml config-as-code — the dashboard's transcoding page is overwritten
on every restart, deliberately.

servarr carries Sonarr, Radarr and Prowlarr from one table; they differ only in
name, port and tile. No downloader and no VPN: imports are manual, so these
organise and rename rather than fetch.

Two decisions worth keeping straight. Jellyfin is the only route with no
authelia middleware, because a TV or phone client cannot complete a browser SSO
round trip — it authenticates them itself against LLDAP, which is what LLDAP is
for. The *arr sit behind the middleware and delegate to it entirely: "Forms" is
a trap, since those apps only offer the screen that creates their first user
while no auth method is configured, so setting one before first run leaves a
login page over an empty user table.

UMask=0002 on the two writers is load-bearing rather than tidy. The NAS dataset
carries a POSIX default ACL granting the media group write, but a default ACL's
effective permission is capped by the mask the creation mode implies: a
directory made under the modules' 0022 lands group r-x, and a file dropped in
over SMB from a desktop can no longer be organised into it.

The media group's gid is read back from the NAS, not chosen — TrueNAS allocated
3006, not the 3000 its range starts at, and a number invented here would put
the services in a group matching nothing.

Prowlarr additionally runs with DynamicUser off, for the same reason lldap
does: a uid allocated per boot cannot own preserved state. All three take a
flat dataDir, because their default buries config below an intermediate
directory their tmpfiles rules create as root inside a service-owned parent,
which systemd then refuses to canonicalize on every later run.

backup.nix stages the four services' state and dumps their databases; Jellyfin's
metadata cache is excluded, being artwork it re-fetches on demand. gatus.nix
gains the four endpoints. The desktops mount the same dataset over SMB, since
that is how the manual imports get there.
