### PR TITLE
feat(srv-01): finish the arr stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,38 +174,97 @@ heartbeat to something off-site.
 
 ### Media on srv-01
 
-Three aspects, split along the lines that actually differ:
+Seven aspects, split along the lines that actually differ:
 
 - **`mediaLibrary`** (`modules/server/media-library.nix`) — the storage, declared once and read by
-  the other two. The bytes live on the NAS (`main/media/video`, sibling of the `books` dataset
+  the other three. The bytes live on the NAS (`main/media/video`, sibling of the `books` dataset
   Calibre-web uses) and reach srv-01 over **NFS**, via a `_lib/nfs.nix` builder mirroring the CIFS
-  one. NFS rather than CIFS because three services share the tree: CIFS fakes ownership with one
+  one. NFS rather than CIFS because four services share the tree: CIFS fakes ownership with one
   mount identity for all of them, where NFS carries real uid/gid and does hardlinks and atomic
-  renames — what the *arr do on every import, and what a downloader would need later.
+  renames — what the *arr do on every import.
 - **`jellyfin`** (`modules/server/jellyfin.nix`) — transcoding runs here and not on the NAS
   *because of the silicon*: srv-01's i5-9500T has a UHD 630 that decodes HEVC 10-bit and tone-maps
   HDR→SDR in fixed-function hardware, against the NAS's Celeron J4125. VAAPI rather than QSV (on
   Gen9.5 the QSV path wants the legacy libmfx runtime for no gain), and `forceEncodingConfig`
   makes `encoding.xml` config-as-code — the dashboard's transcoding page is overwritten on every
-  restart, deliberately.
+  restart, deliberately. The OpenCL half is **`intel-compute-runtime-legacy1`**, not
+  `intel-compute-runtime`: Intel split NEO and the current package supports 12th Gen and newer,
+  while this Gen9.5 GPU (PCI `0x3e92`) is in the legacy branch with Gen8/Gen11. Picking the wrong
+  one looks like a missing driver rather than an unsupported GPU — the ICD installs, ffmpeg loads
+  it, then enumerates nothing (`Failed to get number of OpenCL platforms: -1001`) and the
+  HDR→SDR tone-map filter's `hwmap` dies with `No such device`. VAAPI keeps working throughout, so
+  only HDR content fails.
 - **`servarr`** (`modules/server/servarr.nix`) — Sonarr, Radarr and Prowlarr as one aspect
-  driven by a table, since they differ only in name, port and tile. No downloader: imports are
-  manual, so these organise and rename rather than fetch.
+  driven by a table, since they differ only in name, port and tile.
+- **`sabnzbd`** (`modules/server/sabnzbd.nix`) — the downloader the *arr hand releases to.
+  Usenet only, so nothing seeds and nothing needs a hardlink to keep a file alive after import.
+  Its two directories are split on purpose: **incomplete is local** (par2 repair and unrar rewrite
+  the same bytes repeatedly, which belongs on the NVMe), **complete is inside the library export**
+  (`/mnt/media/downloads`), so a finished file crosses the network once and the *arr import is a
+  rename within one filesystem. A separate `downloads` dataset on the NAS would undo exactly that
+  — a different dataset is a different filesystem, and `rename(2)` would fall back to a copy.
 
-Two things are easy to get wrong here:
+- **`bazarr`** (`modules/server/bazarr.nix`) — subtitles. It writes `.srt` *beside* each video
+  rather than into a store of its own, so it needs the `media` group and `UMask = "0002"` exactly
+  as the *arr do, and Jellyfin then finds the subtitles with no configuration. Its listen address
+  is `general.ip` in its own config file, not a CLI flag, so unlike everything else here it cannot
+  be bound to the loopback from Nix — the firewall is what keeps it off the LAN.
+- **`recyclarr`** (`modules/server/recyclarr.nix`) — quality profiles as code, synced nightly from
+  the TRaSH guides. Uses the **plain English** profiles rather than the `french-*` ones upstream
+  also ships: they select from the widest pool of releases, which matters when a backbone can be
+  missing most of a release's articles, and `bazarr` supplies French afterwards. 1080p and 2160p
+  profiles are synced side by side. The **only media aspect with no preserved state and no backup
+  entry** — its directory is a clone of the guides plus a config generated from the repo, so it
+  rebuilds itself, which is also why its uid is left unpinned where every sibling has one.
+  Two v8-specific traps, both of which fail misleadingly: **`include:` no longer exists** (the
+  `config-templates` v8 branch ships `includes.json` as `{"radarr": [], "sonarr": []}` and replaced
+  the fragments with whole starter configs, so an include dies with "Unable to find include
+  template with name …" as though it were a typo — profiles are referenced by guide `trash_id`
+  instead), and **instance names must be unique across both services**, not just within one, as
+  must `base_url`s. Naming both instances `main` makes recyclarr log `Duplicate instances` at
+  *debug* level, sync nothing, and **exit 0** — a green timer that never updates anything.
+- **`jellyseerr`** (`modules/server/jellyseerr.nix`) — the request front end. nixpkgs renamed the
+  module to **`services.seerr`** (it serves Plex and Emby too now), so the unit is `seerr.service`
+  while the aspect, route, tile and state directory keep the Jellyseerr name.
 
-- **Jellyfin is the one route with no Authelia middleware** (`mkRouter`, not `mkAutheliaRouter`).
+Three things are easy to get wrong here:
+
+- **Jellyfin and Jellyseerr are the two routes with no Authelia middleware** (`mkRouter`, not
+  `mkAutheliaRouter`).
   A TV or phone client cannot complete a browser SSO round trip, so Jellyfin authenticates them
-  itself against LLDAP — that is what LLDAP is *for*. The *arr, browser-only admin UIs, sit behind
+  itself against LLDAP — that is what LLDAP is *for*. Jellyseerr is exempt by extension: it
+  authenticates against Jellyfin, so the household needs no Authelia account and no second login
+  to request something from a phone. The *arr and Bazarr, browser-only admin UIs, sit behind
   the middleware and delegate to it entirely (`auth.method = "External"`). Do not "harden" that
   back to `"Forms"`: these apps only offer the screen that creates their first user while no
   method is configured, so setting one before first run leaves a login page, an empty user table
   and no way in.
-- **`UMask = "0002"` on Sonarr and Radarr is load-bearing**, and forced over the modules' 0022.
+- **SABnzbd's ini is generated but writable**, and its providers are in sops. `configFile = null`
+  makes `modules/server/sabnzbd.nix` the source of truth; the module merges the existing file
+  *under* the generated one, so every declared key wins on each activation and a UI edit to one
+  survives only until the next deploy. `allowConfigWrite = true` is not laziness — SABnzbd tries
+  to save its config every 30s, and against a read-only file each attempt logs `Cannot write to
+  INI file`, which put 7000 lines into `sabnzbd.log` in under two hours and buried real errors.
+  `misc.config_lock` does not help (only the web UI reads it; `save_config()` checks
+  `is_writable()` unconditionally). The cost: a key *removed* from the Nix file is no longer
+  removed from the ini, so deleting a server section means deleting `/var/lib/sabnzbd/sabnzbd.ini`
+  on the host — safe, since it is regenerated. Both options key off `system.stateVersion` (25.11
+  here), *not* the nixpkgs release, so below 26.05 they default the legacy mutable way and have to
+  be stated. Section names (`[[unlimited]]`, `[[block]]`) are ids: SABnzbd keys servers by section
+  name and connects using `host`, so every provider's hostname, username and password is a sops
+  placeholder and nothing about the accounts reaches the store. **Two backbones, split by role** —
+  the flat-rate `unlimited` at priority 0, the metered `block` at 1 with `required = false`, so
+  the block is spent only on articles the first returns 430 for. One backbone is a single point of
+  *availability*: a 430 is final, and a release arriving 82% missing is what a takedown looks like
+  from the client side, not a misconfiguration. The api and nzb keys come from sops for a duller
+  reason: SABnzbd invents them on first start and writes them back, so without them pinned a
+  restore or a wiped ini would hand the *arr a key that no longer works.
+- **`UMask = "0002"` on Sonarr, Radarr and SABnzbd is load-bearing**, and forced over the *arr
+  modules' 0022 (SABnzbd's module sets none, so that one is a plain assignment).
   The NAS dataset carries a POSIX default ACL granting the `media` group write, but a default
   ACL's effective permission is capped by the mask the creation mode implies: a directory created
-  under 0022 lands group `r-x`, and the next writer — a manual copy over SMB from a desktop —
-  cannot write into it. The `media` gid (3006) is **read back from the NAS**, not chosen — TrueNAS
+  under 0022 lands group `r-x`, and the next writer — the *arr moving a finished download out of
+  it, or a manual copy over SMB from a desktop — cannot write into it. The `media` gid (3006) is **read back from the NAS**, not chosen — TrueNAS
   allocated it, and a number invented here would put the services in a group matching nothing. The
   export maps every request to `media:media`, so client *uids* never have to line up.
 
@@ -292,7 +351,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Calibre-web, Jellyfin + the *arr over an NFS library from the NAS, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Calibre-web, Jellyfin + the *arr + SABnzbd over an NFS library from the NAS, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01"
 
 ### Module Organization
 
@@ -300,7 +359,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -346,7 +405,7 @@ Defined in `modules/nixpkgs.nix` (`config.flake.overlays.default`): pulls specif
 ### Key Dependencies
 
 Major flake inputs:
-- `nixpkgs`: NixOS 25.11 stable
+- `nixpkgs`: NixOS 26.05 stable
 - `unstable`: nixos-unstable for bleeding-edge packages
 - `home-manager`: User environment management
 - `disko`: Declarative disk partitioning
@@ -439,7 +498,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `calibre`, `printing`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -284,18 +284,23 @@ The media services restore the same way — indexers, quality profiles, librarie
 none of which is reproducible from a rebuild:
 
 ```bash
-systemctl stop jellyfin sonarr radarr prowlarr
+systemctl stop jellyfin sonarr radarr prowlarr bazarr seerr
 
-for svc in jellyfin sonarr radarr prowlarr; do
+for svc in jellyfin sonarr radarr prowlarr bazarr jellyseerr; do
   rsync -a <pulled>/$svc/ /var/lib/$svc/
   chown -R $svc:$svc /var/lib/$svc
 done
 
-systemctl start jellyfin sonarr radarr prowlarr
+systemctl start jellyfin sonarr radarr prowlarr bazarr seerr
 ```
 
+The unit is `seerr.service` while its state lives in `/var/lib/jellyseerr` — nixpkgs renamed the
+module, the directory predates the rename, and the loop above reflects both.
+
 Jellyfin's artwork is deliberately not in the backup — it re-fetches it — so expect the libraries
-to look bare until the first metadata scan finishes. The media itself was never at risk: it lives
+to look bare until the first metadata scan finishes. Neither SABnzbd nor Recyclarr is in the
+backup either: the first holds a re-downloadable queue, the second a clone of the TRaSH guides and
+a config generated from the repo, so both rebuild themselves. The media itself was never at risk: it lives
 on the NAS, and srv-01 only mounts it.
 
 The staged copy is read by a single unprivileged account, so ownership is flattened on the way

--- a/modules/gui-apps.nix
+++ b/modules/gui-apps.nix
@@ -6,6 +6,8 @@
       home.packages = with pkgs; [
         discord
         vlc
+        # `jellyfin-media-player` is the same derivation under the pre-2.0 name.
+        jellyfin-desktop
         remmina
         obsidian
         mullvad-browser
@@ -39,5 +41,9 @@
     ".config/Signal"
     ".config/obsidian"
     ".config/sone"
+    # Not .config: it keeps both jellyfin-desktop.conf and the web client's
+    # storage.json here, so without this the server address and login are gone
+    # on every reboot.
+    ".local/share/jellyfin-desktop"
   ];
 }

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -20,6 +20,10 @@
         mediaLibrary
         jellyfin
         servarr
+        sabnzbd
+        bazarr
+        recyclarr
+        jellyseerr
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -36,7 +36,14 @@
         "/var/lib/sonarr"
         "/var/lib/radarr"
         "/var/lib/prowlarr"
+        # Language profiles, provider logins and what has already been fetched.
+        "/var/lib/bazarr"
+        # Requests, and the Jellyfin accounts allowed to make them.
+        "/var/lib/jellyseerr"
       ];
+      # Not here on purpose: sabnzbd, whose state is a re-downloadable queue, and
+      # recyclarr, whose directory is a clone of the TRaSH guides plus a config
+      # generated from ./recyclarr.nix. Both rebuild themselves.
 
       # Live sqlite databases: dumped rather than copied, and excluded from the
       # rsyncs above for the same reason. All sit under /var/lib and the staging
@@ -49,6 +56,8 @@
         "${config.services.prowlarr.dataDir}/prowlarr.db"
         "${jellyfinDir}/data/jellyfin.db"
         "${jellyfinDir}/data/library.db"
+        "${config.services.bazarr.dataDir}/db/bazarr.db"
+        "${config.services.seerr.configDir}/db/db.sqlite3"
       ];
     in
     {

--- a/modules/server/bazarr.nix
+++ b/modules/server/bazarr.nix
@@ -1,0 +1,74 @@
+{ ... }:
+{
+  # Subtitles for the library ./servarr.nix fills. It writes `.srt` *beside*
+  # each video rather than into a store of its own, which is why it needs the
+  # same library access and UMask the *arr do — and why Jellyfin then finds the
+  # subtitles with no configuration at all.
+  #
+  # ./recyclarr.nix syncs the plain English profiles, so releases are chosen for
+  # availability rather than language: this is the piece that supplies French.
+  nixos.modules.bazarr =
+    {
+      config,
+      constants,
+      mediaLibrary,
+      mkAutheliaRouter,
+      ...
+    }:
+    {
+      users = {
+        users.bazarr = {
+          # Pinned like jellyfin's and prowlarr's: the module's `isSystemUser`
+          # has no static id, so the preserved state below would stop being
+          # readable across a rebuild (../preservation.nix). 354 is ./sabnzbd.nix.
+          uid = 355;
+          extraGroups = [ mediaLibrary.group ];
+        };
+        groups.bazarr.gid = 355;
+      };
+
+      homepageTiles.Services = [
+        {
+          Bazarr = {
+            icon = "bazarr.png";
+            href = "https://bazarr.${constants.domain}";
+            siteMonitor = "https://bazarr.${constants.domain}";
+            description = "Subtitle manager";
+          };
+        }
+      ];
+
+      services = {
+        bazarr.enable = true;
+
+        # Browser-only admin UI, so the same treatment as the *arr — except that
+        # this one cannot be held to the loopback from here: Bazarr reads its
+        # listen address from `general.ip` in its own config and the module
+        # passes only `--port`, so it answers on every interface until that is
+        # set in the UI. The firewall is what keeps it off the LAN meanwhile.
+        traefik.dynamicConfigOptions.http = mkAutheliaRouter {
+          name = "bazarr";
+          port = config.services.bazarr.listenPort;
+        };
+      };
+
+      systemd.services.bazarr = {
+        # Merges with the module's own `[ dataDir ]` rather than colliding with
+        # it: `unitOption` concatenates list-valued definitions.
+        unitConfig.RequiresMountsFor = [ mediaLibrary.dir ];
+        # Load-bearing for the reason spelled out in ./servarr.nix. The module
+        # sets no UMask, so no mkForce.
+        serviceConfig.UMask = "0002";
+      };
+
+      # Language profiles, provider logins and the history of what was already
+      # fetched — none of it reproducible, so ./backup.nix stages it too.
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = config.services.bazarr.dataDir;
+          inherit (config.services.bazarr) user group;
+          mode = "0700";
+        }
+      ];
+    };
+}

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -191,6 +191,8 @@
               (mkAutheliaHttps { name = "sonarr"; })
               (mkAutheliaHttps { name = "radarr"; })
               (mkAutheliaHttps { name = "prowlarr"; })
+              (mkAutheliaHttps { name = "sabnzbd"; })
+              (mkAutheliaHttps { name = "bazarr"; })
               (mkAutheliaHttps {
                 name = "traefik";
                 path = "/dashboard/";
@@ -206,6 +208,13 @@
               (mkHttps {
                 name = "jellyfin";
                 path = "/health";
+              })
+              # Exempt from the middleware too, so this reaches Jellyseerr
+              # itself. `/api/v1/status` is registered ahead of its
+              # `isAuthenticated` middleware, so it answers without a session.
+              (mkHttps {
+                name = "jellyseerr";
+                path = "/api/v1/status";
               })
               (mkHttps { name = "immich"; })
               (mkHttps {
@@ -248,6 +257,11 @@
               (mkCron {
                 name = "nixos-upgrade";
                 interval = "30h";
+              })
+              # Daily plus up to 5 min of jitter (./recyclarr.nix).
+              (mkCron {
+                name = "recyclarr";
+                interval = "26h";
               })
             ];
           };

--- a/modules/server/jellyfin.nix
+++ b/modules/server/jellyfin.nix
@@ -48,7 +48,13 @@
         enable = true;
         extraPackages = with pkgs; [
           intel-media-driver
-          intel-compute-runtime
+          # `-legacy1`, not plain `intel-compute-runtime`: Intel split NEO and
+          # the current one supports 12th Gen and newer only, while this UHD 630
+          # is Gen9.5. The wrong one reads like a missing driver rather than an
+          # unsupported GPU — the ICD installs, ffmpeg loads it, and it then
+          # enumerates nothing (`OpenCL platforms: -1001`), so only the HDR
+          # tone-map path dies. VAAPI is unaffected throughout.
+          intel-compute-runtime-legacy1
         ];
       };
 

--- a/modules/server/jellyseerr.nix
+++ b/modules/server/jellyseerr.nix
@@ -1,0 +1,80 @@
+{ ... }:
+{
+  # The request front end: the household asks for a film or a series here rather
+  # than touching Sonarr and Radarr directly.
+  #
+  # nixpkgs renamed the module to `services.seerr` (it serves Plex and Emby too
+  # now), so the unit is `seerr.service` while the aspect, route, tile and state
+  # directory keep the Jellyseerr name.
+  nixos.modules.jellyseerr =
+    {
+      config,
+      constants,
+      lib,
+      mkRouter,
+      ...
+    }:
+    {
+      users = {
+        # DynamicUser is turned off below, so this account has to exist and keep
+        # the same id across boots.
+        users.jellyseerr = {
+          isSystemUser = true;
+          group = "jellyseerr";
+          # 355 is ./bazarr.nix.
+          uid = 356;
+        };
+        groups.jellyseerr.gid = 356;
+      };
+
+      homepageTiles.Services = [
+        {
+          Jellyseerr = {
+            icon = "jellyseerr.png";
+            href = "https://jellyseerr.${constants.domain}";
+            siteMonitor = "https://jellyseerr.${constants.domain}";
+            description = "Media requests";
+          };
+        }
+      ];
+
+      services = {
+        seerr.enable = true;
+
+        # `mkRouter`, not `mkAutheliaRouter`, by extension from ./jellyfin.nix:
+        # it authenticates against Jellyfin, so the middleware would mean an
+        # Authelia account per household member and two logins from a phone.
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "jellyseerr";
+          inherit (config.services.seerr) port;
+        };
+      };
+
+      systemd.services.seerr = {
+        # The module sets only PORT, so without this it listens on every
+        # interface. Undocumented but real: the bundle reads `process.env.HOST`
+        # and passes it to `.listen(port, host)`.
+        environment.HOST = "127.0.0.1";
+        serviceConfig = {
+          # Same reason as ./lldap.nix and prowlarr in ./servarr.nix: a uid
+          # allocated per boot cannot own preserved state. Turning it off also
+          # moves the state out of /var/lib/private.
+          DynamicUser = lib.mkForce false;
+          User = "jellyseerr";
+          Group = "jellyseerr";
+        };
+      };
+
+      # Hardcoded rather than derived from `configDir`: the module picks that and
+      # StateDirectory together off `system.stateVersion` (25.11 here, so
+      # /var/lib/jellyseerr/config), and they stop sharing a parent at 26.05.
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = "/var/lib/jellyseerr";
+          user = "jellyseerr";
+          group = "jellyseerr";
+          mode = "0700";
+        }
+      ];
+    };
+}

--- a/modules/server/recyclarr.nix
+++ b/modules/server/recyclarr.nix
@@ -62,6 +62,16 @@
               # the definition above.
               "20e0fc959f1f1704bed501f23bdae76f" # [Anime] Remux-1080p
             ];
+            # The pair only makes sense together: the OLED does Dolby Vision, so
+            # prefer it (+1000), but phones and browsers also play these files,
+            # so reject the single-layer profile 5 releases that carry no HDR10
+            # base layer (-10000) — those render green on anything without DV.
+            # Profile 8.1 keeps both audiences happy from one file, which is
+            # what "fallback" means here; nothing is downloaded twice.
+            custom_format_groups.add = [
+              { trash_id = "e0b2774083df4265f25c9e5bc6c80940"; } # [HDR Formats] DV Boost
+              { trash_id = "d776a1ea912a117d66d83b880ff2055d"; } # [HDR Formats] DV (w/o HDR fallback)
+            ];
           };
           radarr.radarr-main = {
             base_url = "http://localhost:7878";
@@ -70,6 +80,11 @@
             quality_profiles = profiles [
               "d1d67249d3890e49bc12e275d989a7e9" # HD Bluray + WEB
               "64fb5f9858489bdac2af690e27c8f42f" # UHD Bluray + WEB
+            ];
+            # Same pairing as Sonarr's, with Radarr's own ids for the groups.
+            custom_format_groups.add = [
+              { trash_id = "1616617ab3a14397a2b2321bcbda44d1"; } # [HDR Formats] DV Boost
+              { trash_id = "7fc2751eef7e6bdc70b74136e5e35c76"; } # [HDR Formats] DV (w/o HDR fallback)
             ];
           };
         };

--- a/modules/server/recyclarr.nix
+++ b/modules/server/recyclarr.nix
@@ -1,0 +1,88 @@
+{ ... }:
+{
+  # Quality profiles as code. Everything else Sonarr and Radarr know lives in
+  # their sqlite databases and survives only because ./backup.nix stages them;
+  # this is the one part of their configuration that is declared here and
+  # re-applied nightly from the TRaSH guides.
+  #
+  # The plain English profiles, deliberately, rather than the `french-*` ones
+  # upstream also ships: they select clean original-audio releases from the
+  # widest pool, which matters when a single backbone can be missing 82% of a
+  # release's articles, and ./bazarr.nix supplies French subtitles afterwards.
+  # 1080p and 2160p profiles are synced side by side and chosen per title —
+  # ./jellyfin.nix can tone-map 4K HDR in fixed-function hardware.
+  #
+  # Profiles are referenced by **guide trash_id, not template name**: recyclarr 8
+  # removed `include:` altogether (its v8 template branch ships an empty
+  # `includes.json`), and an include now dies with "Unable to find include
+  # template with name …" as though it were a typo. The ids below come from the
+  # v8 starter templates of the same name.
+  nixos.modules.recyclarr =
+    {
+      config,
+      mkHeartbeat,
+      ...
+    }:
+    let
+      # `reset_unmatched_scores` is what makes the sync authoritative: scores the
+      # guide does not set are reset rather than left at whatever the app had.
+      profiles = map (trash_id: {
+        inherit trash_id;
+        reset_unmatched_scores.enabled = true;
+      });
+    in
+    {
+      services.recyclarr = {
+        enable = true;
+        configuration = {
+          # Instance names must be unique across *both* services, as must
+          # base_urls. Calling them both `main` is the obvious thing and fails
+          # in the worst way available: recyclarr logs `Duplicate instances` at
+          # debug level, syncs nothing and exits 0 — a green timer that never
+          # updates anything.
+          sonarr.sonarr-main = {
+            base_url = "http://localhost:8989";
+            # The same sops entry ./servarr.nix renders Sonarr's own environment
+            # file from, not a second copy of the key.
+            api_key._secret = config.sops.secrets.sonarrApiKey.path;
+            # Sonarr's quality definitions are *global* — one set of size limits
+            # for every profile — so `series` and `anime` cannot both be synced,
+            # and live action is the majority. They differ only in the minimum
+            # size: `series` floors Bluray-1080p at 50.4 MB/min against `anime`'s
+            # 5, and a lot of anime lands under that. **If anime releases start
+            # being rejected as too small, this is why**, and the fix is the one
+            # word `anime` here.
+            quality_definition.type = "series";
+            quality_profiles = profiles [
+              "72dae194fc92bf828f32cde7744e51a1" # WEB-1080p
+              "d1498e7d189fbe6c7110ceaabb7473e6" # WEB-2160p
+              # Its cutoff is Bluray 1080p despite the name, so it stops there
+              # rather than chasing 20GB files. What it brings is anime-specific
+              # custom-format scoring, which is per-profile and so unaffected by
+              # the definition above.
+              "20e0fc959f1f1704bed501f23bdae76f" # [Anime] Remux-1080p
+            ];
+          };
+          radarr.radarr-main = {
+            base_url = "http://localhost:7878";
+            api_key._secret = config.sops.secrets.radarrApiKey.path;
+            quality_definition.type = "movie";
+            quality_profiles = profiles [
+              "d1d67249d3890e49bc12e275d989a7e9" # HD Bluray + WEB
+              "64fb5f9858489bdac2af690e27c8f42f" # UHD Bluray + WEB
+            ];
+          };
+        };
+      };
+
+      # Nothing breaks when a sync fails, but a sync that quietly stopped means
+      # the profiles stop tracking the guides, which is otherwise invisible.
+      systemd.services.recyclarr.serviceConfig = mkHeartbeat "recyclarr";
+
+      # No `preservation` entry and nothing in ./backup.nix, on purpose:
+      # /var/lib/recyclarr is the cloned guides plus a config.yml generated from
+      # the attrset above, both rebuilt on the next run. Same argument
+      # ./gatus.nix makes for its sqlite store, and it is why this user's uid is
+      # left unpinned where every sibling has one.
+    };
+}

--- a/modules/server/sabnzbd.nix
+++ b/modules/server/sabnzbd.nix
@@ -1,0 +1,246 @@
+{ ... }:
+{
+  # The downloader ./servarr.nix was missing: Sonarr and Radarr hand a release to
+  # SABnzbd, it fetches, repairs and unpacks it, and they rename what comes out
+  # into the library. Usenet only — no torrent client, so nothing here seeds and
+  # nothing needs a hardlink to keep a file alive after import.
+  #
+  # Where the two directories live is the load-bearing decision. Incomplete is
+  # local: par2 repair and unrar rewrite the same bytes several times, which
+  # belongs on the NVMe rather than on the far side of NFS. Complete is *inside*
+  # the library export, so a finished file crosses the network exactly once and
+  # the *arr import is a rename within one filesystem rather than a copy. A
+  # separate `downloads` dataset on the NAS would undo that — a different dataset
+  # is a different filesystem, and rename(2) would fall back to a copy.
+  nixos.modules.sabnzbd =
+    {
+      config,
+      constants,
+      lib,
+      mediaLibrary,
+      mkAutheliaRouter,
+      ...
+    }:
+    let
+      # 8080 is ./gatus.nix, which sabnzbd would otherwise collide with.
+      port = 8085;
+      stateDir = "/var/lib/sabnzbd";
+      completeDir = "${mediaLibrary.dir}/downloads";
+
+      # Name → subdirectory of completeDir. Sonarr and Radarr name one of these
+      # when they hand over a release. The `*` entry is the default and has to
+      # exist. (`pp = 3` below is repair + unpack + delete; priority -100 means
+      # "inherit the default category's".)
+      categories = {
+        "*" = "";
+        tv = "tv";
+        movies = "movies";
+      };
+
+      # Placeholder in the generated ini → the sops key holding its value. One
+      # table rather than two lists, so a secret cannot be declared without also
+      # being substituted — which would leave the `@…@` literal in the config.
+      secrets = {
+        "@sabnzbd_api_key@" = "sabnzbdApiKey";
+        "@sabnzbd_nzb_key@" = "sabnzbdNzbKey";
+        "@unlimited_host@" = "sabnzbdUnlimitedHost";
+        "@unlimited_username@" = "sabnzbdUnlimitedUsername";
+        "@unlimited_password@" = "sabnzbdUnlimitedPassword";
+        "@block_host@" = "sabnzbdBlockHost";
+        "@block_username@" = "sabnzbdBlockUsername";
+        "@block_password@" = "sabnzbdBlockPassword";
+      };
+    in
+    {
+      users = {
+        users.sabnzbd = {
+          # Pinned like jellyfin's and prowlarr's: nixpkgs commented sabnzbd out
+          # of ids.nix ahead of 26.05, so `isSystemUser` would take a per-boot
+          # uid and the preserved state below would stop being readable
+          # (../preservation.nix). 353 is ./servarr.nix's prowlarr.
+          uid = 354;
+          # The export squashes every request to media:media, but the client
+          # kernel still checks locally against the ownership it is shown — as
+          # in ./servarr.nix.
+          extraGroups = [ mediaLibrary.group ];
+        };
+        groups.sabnzbd.gid = 354;
+      };
+
+      homepageTiles.Services = [
+        {
+          SABnzbd = {
+            icon = "sabnzbd.png";
+            href = "https://sabnzbd.${constants.domain}";
+            siteMonitor = "https://sabnzbd.${constants.domain}";
+            description = "Usenet downloader";
+          };
+        }
+      ];
+
+      # Owned by sabnzbd because the module's preStart — which reads them through
+      # `replace-secret` — runs under `User=sabnzbd`, not root.
+      sops.secrets = lib.genAttrs (lib.attrValues secrets) (_: {
+        owner = "sabnzbd";
+      });
+
+      services = {
+        sabnzbd = {
+          enable = true;
+
+          # Both of these switch on `system.stateVersion`, not on the nixpkgs
+          # release: below 26.05 they default the legacy way — `configFile` to a
+          # mutable path, which makes everything in `settings` ignored outright.
+          # This host is pinned at 25.11 and stays there, so they are stated
+          # rather than inherited.
+          configFile = null;
+          # Writable, but still generated from here: the module merges the
+          # existing file *under* the generated one, so every key below wins on
+          # each activation. What it buys is silence — SABnzbd tries to save its
+          # config every 30s, and against a read-only file each attempt logs
+          # `Cannot write to INI file`, which buried the errors that mattered.
+          # (`misc.config_lock` does not help; only the web UI reads it, while
+          # save_config() checks is_writable() unconditionally.) The cost is that
+          # a key *removed* from this file is no longer removed from the ini.
+          allowConfigWrite = true;
+
+          # `secretValues` keeps the whole structure here and substitutes only
+          # the values at start, where `secretFiles` would move a second ini
+          # fragment into sops. The hosts are placeholders like the credentials:
+          # which providers these are belongs in sops, not in a public repo.
+          secretValues = lib.mapAttrs (_: key: config.sops.secrets.${key}.path) secrets;
+
+          settings = {
+            misc = {
+              # Traefik is the only way in: bound to loopback, and `openFirewall`
+              # left at its default false, as in ./servarr.nix.
+              host = "127.0.0.1";
+              inherit port;
+
+              # Pinned rather than generated: SABnzbd invents both on first start
+              # and writes them back, so a restore or a wiped ini would hand the
+              # *arr a key that no longer works.
+              api_key = "@sabnzbd_api_key@";
+              nzb_key = "@sabnzbd_nzb_key@";
+
+              # Anti-DNS-rebinding check: SABnzbd refuses a Host header that is
+              # neither localhost nor an IP unless it is listed here, which is
+              # every request arriving through Traefik. Without it the UI answers
+              # "Access denied" behind a perfectly working router.
+              host_whitelist = "sabnzbd.${constants.domain}";
+
+              download_dir = "${stateDir}/incomplete";
+              complete_dir = completeDir;
+
+              # Pauses the queue instead of filling the disk the nix store shares.
+              # Only the incomplete side needs it; the NAS reports its own
+              # capacity through TrueNAS' alert service.
+              download_free = "25G";
+
+              # Well under SABnzbd's "25% of memory" advice: `/` is a tmpfs here
+              # and already claims 25% (../_hosts/srv-01/disks.nix).
+              cache_limit = "512M";
+            };
+
+            # Built from the table above so the sections here and the
+            # directories created in preStart cannot drift apart.
+            categories = lib.mapAttrs (name: dir: {
+              pp = "3";
+              script = "None";
+              priority = if name == "*" then 0 else -100;
+              inherit dir;
+            }) categories;
+
+            # Section keys are ids, not hostnames: SABnzbd connects using `host`
+            # and ignores `name` entirely (sabnzbd/config.py, ConfigServer), so
+            # nothing here names the provider — that is all in sops.
+            #
+            # Two backbones, because one is a single point of *availability*: a
+            # 430 for an article is final, and an 82%-missing release is what a
+            # takedown looks like from the client side. Split by role, which is
+            # what sets the priorities.
+            servers = {
+              # Flat-rate, so it goes first (priority 0 is highest). Worth
+              # keeping on a different backbone from the block — a second
+              # reseller of the same spool would fail on the same articles.
+              unlimited = {
+                name = "unlimited";
+                displayname = "Unlimited";
+                enable = true;
+                host = "@unlimited_host@";
+                port = 563;
+                ssl = true;
+                username = "@unlimited_username@";
+                password = "@unlimited_password@";
+                # Adjust to whatever the account actually allows.
+                connections = 30;
+                priority = 0;
+                # Wait for it rather than declare articles missing on a
+                # transient failure — it is meant to serve nearly everything.
+                required = true;
+              };
+              # Metered, so it is spent only on the articles `unlimited` returned
+              # 430 for. `required = false` so a block that has run out is
+              # skipped rather than stalling the queue behind it.
+              block = {
+                name = "block";
+                displayname = "Block";
+                host = "@block_host@";
+                port = 563;
+                ssl = true;
+                username = "@block_username@";
+                password = "@block_password@";
+                # The account allows 50 across every client using it.
+                connections = 20;
+                priority = 1;
+                required = false;
+              };
+            };
+          };
+        };
+
+        # A browser-only admin UI, so the same treatment as the *arr. Sonarr and
+        # Radarr are unaffected: they reach the API on the loopback, behind the
+        # middleware rather than through it, so nothing needs exempting the way
+        # ./jellyfin.nix does.
+        traefik.dynamicConfigOptions.http = mkAutheliaRouter {
+          name = "sabnzbd";
+          inherit port;
+        };
+      };
+
+      systemd.services.sabnzbd = {
+        unitConfig.RequiresMountsFor = [ mediaLibrary.dir ];
+
+        # SABnzbd only creates a category's directory when a job first completes
+        # into it, and until then Sonarr and Radarr fail RemotePathMappingCheck
+        # with "…cannot see this directory. You may need to adjust the folder's
+        # permissions" — which reads as a permissions fault and is not one.
+        preStart = lib.mkAfter ''
+          mkdir -p ${
+            lib.escapeShellArgs (
+              map (dir: if dir == "" then completeDir else "${completeDir}/${dir}") (lib.attrValues categories)
+            )
+          }
+        '';
+
+        # Load-bearing for the same reason as ./servarr.nix: a directory created
+        # under 0022 lands group `r-x` on the NAS and the *arr cannot move the
+        # finished download out of it. The module sets no UMask, so no mkForce.
+        serviceConfig.UMask = "0002";
+      };
+
+      # `/` is a tmpfs, so an unpreserved incomplete directory would download
+      # into RAM and lose half-finished jobs on the reboot ../auto-upgrade.nix
+      # may take overnight. Deliberately *not* staged in ./backup.nix: with the
+      # config generated from this file, the rest is a re-downloadable queue.
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = stateDir;
+          user = "sabnzbd";
+          group = "sabnzbd";
+          mode = "0700";
+        }
+      ];
+    };
+}

--- a/modules/server/servarr.nix
+++ b/modules/server/servarr.nix
@@ -2,8 +2,8 @@
 {
   # Sonarr, Radarr and Prowlarr in one aspect: they are deployed together, share
   # the library mount, the sops shape and the Authelia routers, and differ only
-  # in the table below. No downloader — imports are manual for now, so these are
-  # a renamer, a renamer and an indexer manager.
+  # in the table below. The downloader they hand releases to is its own aspect,
+  # ./sabnzbd.nix — it shares none of that shape.
   nixos.modules.servarr =
     {
       config,
@@ -64,13 +64,23 @@
         };
       }) apps;
 
-      # A single `<APP>__AUTH__APIKEY=…` line each — one file per app rather than
-      # a shared blob, so none of them can read another's key. From sops so the
-      # keys survive a restore instead of being regenerated behind Prowlarr's
-      # back.
-      sops.secrets = lib.mapAttrs' (
-        name: _: lib.nameValuePair "${name}Environment" { owner = name; }
-      ) apps;
+      # The key is the secret; the `<APP>__AUTH__APIKEY=…` line these modules
+      # want is *rendered* from it. Storing the env line directly would mean a
+      # second copy of every key as soon as something needs one bare, which
+      # ./recyclarr.nix does — and two copies of a credential drift. One file per
+      # app rather than a shared blob, so none of them can read another's. From
+      # sops so the keys survive a restore instead of being regenerated behind
+      # Prowlarr's back.
+      sops = {
+        secrets = lib.mapAttrs' (name: _: lib.nameValuePair "${name}ApiKey" { owner = name; }) apps;
+        templates = lib.mapAttrs' (
+          name: _:
+          lib.nameValuePair "${name}Environment" {
+            owner = name;
+            content = "${lib.toUpper name}__AUTH__APIKEY=${config.sops.placeholder."${name}ApiKey"}";
+          }
+        ) apps;
+      };
 
       services =
         lib.genAttrs names (name: {
@@ -96,7 +106,7 @@
               required = "Enabled";
             };
           };
-          environmentFiles = [ config.sops.secrets."${name}Environment".path ];
+          environmentFiles = [ config.sops.templates."${name}Environment".path ];
         })
         // {
           traefik.dynamicConfigOptions.http = lib.mkMerge (

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -19,9 +19,17 @@ autheliaOidcImmichClientSecret: ENC[AES256_GCM,data:OW6+P3vE2bxecvoIT5CB6bfizd/m
 autheliaOidcImmichClientSecretDigest: ENC[AES256_GCM,data:sJyMQcIzN0foj1hJB3zEpkVHc4jueoRrreqHDc0spNV2mkzrdVP20tva3EWBBgzOHhFHvn+KpUP+8xEZ22QDOZ2ioK099sgSlW1AgmXkRkEdbSavYGDZ38yyFEN+8DWu5QyQ/A9FxeR9I9Q6J5R/Hi3EZxMbFrsMo2PdKpXuXKE///Q=,iv:aHIQPCqnyEY9AxrVfKWxNrY+piMzh53a6+840FJ3q7o=,tag:hsBhkMML/kM4tbNan0Vbdw==,type:str]
 gatusEnvironments: ENC[AES256_GCM,data:HgE5omCr5kxoYrRbMZnPLmRQsI6bNx+bbyQaGarR/FNXGuI9kmbB2enEpmLHNoX+rNpYXeciG/PazdMiLqPWyOsGtIsmIOZf/et0WPHeL3tfUuYvjyTexfTgoWMaCGdrMv3HlGrCL9OGGbKFBMvwxkReAzRORH1RYXHvklTWluq7ej9fQpOWihYRbKymXo4EsZpaAasCjoHO1u/ocCemuRuzbCn+jHl7e+H0V2oS6kQbCBCG4kQ3LEMWptQ=,iv:W8d8oAKXmKVQVmxwh17tfdcPsy7gtt7v9MS1aCs1Kk4=,tag:TCGuJZPxemCmA7/WsfaEng==,type:str]
 beszelAgentEnvironment: ENC[AES256_GCM,data:pmdc/qWTgvfEeOVVhwz9Bsk7NXWk90Eeg8svnsK21wwcp0+lR9PHZRLsQKTsKoocKa1Otmo1sWYaMiWjfuu6WwXRuuZoqyVyjhMZqS2FFa0lMIt5WZ8QL49d0EGCf8eYzllatojYNLctsILL+Z1y0CRlp9uz+RA1nqKyp9JndNlw/kKN,iv:lh7Bv8D9FvLEm4l6uKIoKeQckK+8I8lc8MNXxKoNMDc=,tag:VrC3jmMh8Z0YBnT5PQnOpA==,type:str]
-sonarrEnvironment: ENC[AES256_GCM,data:x/S8CZZ8VBezyZKNUq+ZUKqQ/Yg0m06WBXn/5RDgyNpgYQzWWugkZyZKCZjTPbI8uTcnGfw=,iv:NsVMXTaWR/ZzYioued/SRiv3JGqDpb8qaIBskQbMZCE=,tag:zshUj0yayPX2r4xiN3lIZQ==,type:str]
-radarrEnvironment: ENC[AES256_GCM,data:78OtTB96AjmJLQxrLqRcHf2AenNC5yqbR8JSeFOiwIVaBTnp1RVjdcCmwUi6KcbyZUevM4M=,iv:aKTOwBZYqJzJpapT0EbNgRSU1NM91cPERUg655IXqfs=,tag:hapGR78o7LQAhegutWsgoA==,type:str]
-prowlarrEnvironment: ENC[AES256_GCM,data:1LdydNmImO16R2ZeODIXqxzluiZlyLADC+cQMY2FwW0mWrB5YzZnoyO3zaQlNTE0TiwXSpZtwQ==,iv:mZ4vjoPwC3bqovunZb8oiyItXINheV2ozzNxEQjn+2E=,tag:G8OeJlVWK1ROBUp6QooM7g==,type:str]
+sabnzbdApiKey: ENC[AES256_GCM,data:aJ8FzEBPVRUYLnSqNv8bS77Tj2FWs5/ruBAJTEM7kVg=,iv:9ZgJQX5afoptQHqr5Z1zpL0/Db82Ia5Z8yPDQHZ6Ff4=,tag:RM14Bs8Oz3CIXcQ0IrXnbA==,type:str]
+sabnzbdNzbKey: ENC[AES256_GCM,data:Qm2Gx62FYPONzHz80qhK4XkfA3MGUAg3bmnpuJcqmxk=,iv:isnXDGiIauF/9HnSrJdNqXAo3ho51vyG8u9TyKc3Vfk=,tag:UHZkCnnx64yTOad5Jk2w+A==,type:str]
+sabnzbdBlockHost: ENC[AES256_GCM,data:n7HbBA9Wox9AQGI69QZAwA==,iv:XFABeDUuM1XIAsfLqHaHrnExK1UD9PDIvhKJoZknvLw=,tag:6tWTZSgsmjzun6ti+1Zuyg==,type:str]
+sabnzbdBlockUsername: ENC[AES256_GCM,data:0WGrGxTua7zqvNbdA5TTuQ==,iv:AIy5XzIuW04Zzs5R5qgfnX59YL1jfWygMIZ82+3e9Lc=,tag:RG7Fztqy8PNVXrsq4gMu0w==,type:str]
+sabnzbdBlockPassword: ENC[AES256_GCM,data:Ab7QHpD51PaEYDmsmjPX8g==,iv:w6ExYUKInKsAmqVg4Hl6CLLAFQnu2KuvFt6FWnVKVJE=,tag:ae9xtHwwWGOLcm4ajyKYQA==,type:str]
+sabnzbdUnlimitedHost: ENC[AES256_GCM,data:VEAoegUUCF6b3Lk1vWVm5r5L,iv:rivB1j4D9brNbuCZj6Bq9qJeMugVF0UI99p2NRF0gmw=,tag:Oeri8aL2uIXCRBnCbeoZgQ==,type:str]
+sabnzbdUnlimitedUsername: ENC[AES256_GCM,data:TW/TX/+sXt6RUw==,iv:RGY3/S1fa1M0rGFVoVZD98/zmjaJF6OSbURfZ+NnplE=,tag:01Ahd4wUzPkMykvcipaC2A==,type:str]
+sabnzbdUnlimitedPassword: ENC[AES256_GCM,data:VIOpk59nJ54=,iv:H9KNfJdLdOu5tfYA1d+e1curgzYtzrYTgEO/A+QeBrs=,tag:L1zS5fsFCWS+A+7Br1lSiQ==,type:str]
+sonarrApiKey: ENC[AES256_GCM,data:y44MgxehvFlrL7n80zM9ToarNBlu6E5PRglFOx3Qfi4=,iv:P3kFLI8eW9rfgBVnAmMNw+Se1A2SKcd5TiD39/EOuU0=,tag:wKoDC0razO5KbKqFBCC5Dg==,type:str]
+radarrApiKey: ENC[AES256_GCM,data:Zk9o3cdEhQ4pesA5o3sbtOG6d0J4FP3ZnJxZTXm66i4=,iv:Xhq4ibPc7BD8/aE2iEXP6C14f11M0gpgNwu4y4Esw/M=,tag:hzuuUuAc+Fvefd7kPGGumg==,type:str]
+prowlarrApiKey: ENC[AES256_GCM,data:j7j+kM+19EA7/r8KLPjpAdHf5M7wWBSgvHdL97gKp+w=,iv:t3bnC1ygolAhL1Dmlb86Jl6tYosdjHNRDCkO9h81bwU=,tag:tKDqVcUh06NqvKL/fFLrTA==,type:str]
 sops:
     age:
         - enc: |
@@ -33,8 +41,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-04T16:18:11Z"
-    mac: ENC[AES256_GCM,data:0KBiteYuWyvQv02IWih+7kW58kmGYBYVSKiCy9bM/qEOwScw7PeOgRhkE0JsjdZ1MNbhjAJAogSVjhv76ef5ThH9K/G1bshu+v3Ha6z+bt0Lhr0p+n+hzuVCt8rVR3qlIlB96BLkxBP0ANySZIvfXcPT0AzwSBs5ABGJRGHARH0=,iv:CQ7LcTNtRz3Ti9UyoucS9L/PWzjYtoV92KcIAjNLBlY=,tag:F6qxs4JQvIi356al2WLmRQ==,type:str]
+    lastmodified: "2026-08-05T15:06:40Z"
+    mac: ENC[AES256_GCM,data:b3BnfNFFS7jOn8vXseQVQ/M7dC6JxsXar7RE0mpd5etSb0bI6tMI6gqDPGmBZ0B7mwfEXh/sdV3OnBRrhz0s4eVoVypwZJiUIz4qifKllJZDjWA5mzqqQWCBb416VKpFMkuBn9MnAaaxWp6NC5OE9p4TjTVDTn3d6gYTDccMZVg=,iv:GgYwhnWEYPezkgB5ABfWjxgwyZPciAp+3amSFz1UCgc=,tag:EIaINs/LAB2t4+PrIscBXw==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
- **fix(jellyfin): drive OpenCL on Gen9.5 with the legacy compute runtime**
- **feat(desktop): install the Jellyfin desktop client**
- **feat(srv-01): fetch with SABnzbd and finish the *arr stack**
- **feat(recyclarr): prefer Dolby Vision, but only with an HDR10 fallback**
