### PR TITLE
feat(srv-01): add Mealie for recipes and meal planning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,25 +97,31 @@ Three ways in, because apps fall into three groups:
   so that header contract is load-bearing — it was Calibre-web's before, and moved intact to
   `modules/server/shelfmark.nix` when Calibre-web was removed.
 - **OIDC** — Authelia is also the OIDC provider (`identity_providers.oidc`), for apps that
-  authenticate their own users. Clients are declared in that same file (Immich, Grimmory and
-  Paperless), with the client secret's pbkdf2 digest pulled from sops via `{{ secret "…" }}`
-  rather than committed in cleartext. Discovery lives at
+  authenticate their own users. Clients are declared in that same file (Immich, Grimmory,
+  Paperless and Mealie), with the client secret's pbkdf2 digest pulled from sops via
+  `{{ secret "…" }}` rather than committed in cleartext. Discovery lives at
   `https://auth.<domain>/.well-known/openid-configuration`.
-  **The three clients differ from each other in ways that all fail misleadingly**, so none of them
+  **The four clients differ from each other in ways that all fail misleadingly**, so none of them
   is a template for the next:
   - *Where the claims come from.* Immich and Paperless read **userinfo**; **Grimmory reads the ID
     token**, where Authelia puts only a standard subset. So Grimmory — and only Grimmory — needs a
     `claims_policies` entry naming `preferred_username`, `email`, `name` and `groups`; without it
-    the login succeeds and the group mapping silently does nothing.
+    the login succeeds and the group mapping silently does nothing. Mealie reads the ID token
+    **and falls back to userinfo** when a claim is missing, which is why it needs no policy despite
+    mapping groups the way Grimmory does.
   - *How userinfo is signed.* Immich needs `userinfo_signed_response_alg = "RS256"`. Copying that
     line to **Paperless breaks login outright**: django-allauth calls `.json()` on the userinfo
-    body, and a signed JWT is not JSON. Authelia's default of `none` is the correct one there.
+    body, and a signed JWT is not JSON. Authelia's default of `none` is the correct one there, and
+    for Mealie, whose fallback would meet the same JWT.
   - *Token endpoint auth.* Paperless states `client_secret_post` because allauth reads
     `token_endpoint_auth_methods_supported` from discovery and prefers it whenever advertised; a
     client left on basic auth 401s at the token exchange with nothing useful logged either side.
+    Mealie is the one client that states `client_secret_basic`, because authlib picks that unless
+    told otherwise — the same failure, mirrored.
   Paperless's redirect URI is derived from the `provider_id` in its sops-templated
-  `PAPERLESS_SOCIALACCOUNT_PROVIDERS` (`/accounts/oidc/<provider_id>/login/callback/`), so those
-  two files have to agree byte for byte — a mismatch is reported only as an invalid redirect.
+  `PAPERLESS_SOCIALACCOUNT_PROVIDERS` (`/accounts/oidc/<provider_id>/login/callback/`), and
+  Mealie's from its own `BASE_URL` plus `/login`, so in both cases two files have to agree byte for
+  byte — a mismatch is reported only as an invalid redirect.
 - **LDAP** (`modules/server/lldap.nix`) — for apps that speak neither. Kept **deliberately**: the
   Jellyfin OIDC plugin (`9p4/jellyfin-plugin-sso`) was archived upstream in May 2026 with no
   successor fork, and never completed the flow outside a browser anyway, so LDAP is the only
@@ -138,7 +144,7 @@ hand the plaintext to the app. Authelia refuses to start with an empty client li
 ### Backing up srv-01
 
 srv-01 pushes nothing. The `backup` aspect (`modules/server/backup.nix`) stages the lldap,
-authelia, *arr, Jellyfin, Shelfmark and Grimmory state into `/var/backup/data` at 01:00, and the
+authelia, *arr, Jellyfin, Shelfmark, Grimmory and Mealie state into `/var/backup/data` at 01:00, and the
 TrueNAS *pulls* it over SFTP, so srv-01 holds no credential that reaches its own backups. The
 media is never in scope — it lives on the NAS to begin with — and neither is Jellyfin's metadata
 cache, which is artwork it re-fetches on demand. Retention is the NAS's periodic
@@ -482,6 +488,42 @@ Anything worth keeping is either sent to Paperless, which is in the backup, or d
 scanned photo belongs in Immich on the NAS. Preserving it is also why `scanservjs`'s uid is pinned
 where `recyclarr`'s is not.
 
+### Recipes on srv-01
+
+`mealie` (`modules/server/mealie.nix`) — recipes and meal planning. Another **ordinary nixpkgs
+module** (`services.mealie`), so the `paperless` shape rather than the `grimmory` one: no image tag
+to pin, no Renovate `customManagers` entry, the weekly lockfile PR covers it. Four things are
+easy to get wrong:
+
+- **SQLite, not the PostgreSQL the module can bring up.** `database.createLocally = true` would
+  reuse the cluster `paperless` starts, but `/var/lib/postgresql` is preserved *in
+  `paperless.nix`*, so `mealie` would silently depend on that aspect being imported — the opposite
+  of the loud eval failure `mediaLibrary` and `mkHeartbeat` are built for. As one file at
+  `/var/lib/mealie/mealie.db` it instead falls into `backup.nix`'s existing online-backup loop
+  beside every other sqlite service here.
+- **`settings` is rendered into `Environment=`,** which reaches the store *and* the journal, so the
+  OIDC client secret goes through the module's `credentialsFile` from a sops template — the same
+  split `shelfmark.nix` makes for its API keys. Note also that the module passes every `settings`
+  value through `toString`, and Nix's `toString false` is the **empty string**: booleans have to be
+  written `"true"`/`"false"` or they are silently unset.
+- **`DynamicUser` is forced off** and uid/gid 360 pinned, for the reason `lldap.nix` gives — a uid
+  allocated per boot cannot own preserved state, and it moves the state out of
+  `/var/lib/private/mealie`. What is preserved is the database, the recipe images, and the app
+  secret Mealie generates on first start and signs its tokens with.
+- **The seeded first user is `changeme@example.com` / `MyPassword`, and cannot be configured
+  away.** The env vars behind it are `_DEFAULT_EMAIL`/`_DEFAULT_PASSWORD` — pydantic *private*
+  attributes, which upstream documents as no longer settable by end users. Deleting that account
+  once the first Authelia login has created a real admin is a mandatory bootstrap step, not
+  hygiene; the route carries no Authelia middleware. See README.md, "Bringing up Mealie".
+
+The route is `mkRouter`, not `mkAutheliaRouter`, joining Jellyfin, Jellyseerr, Grimmory and
+Paperless: Mealie has no proxy-header auth mode to delegate to the way the *arr do, and its REST
+API is a client a browser SSO round trip cannot serve. Access is gated instead on the LLDAP groups
+`mealie-users`/`mealie-admins` via `OIDC_USER_GROUP`/`OIDC_ADMIN_GROUP` — and setting either is
+*also* what makes Mealie ask Authelia for the `groups` scope at all, so dropping them would quietly
+take the claim with them. `OIDC_AUTO_REDIRECT` stays off for Paperless's reason: the local login is
+the way in when Authelia is the thing that is down.
+
 ### Formatting and Linting
 
 ```bash
@@ -562,7 +604,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), and Paperless plus the scanner in "Documents on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", and Mealie in "Recipes on srv-01"
 
 ### Module Organization
 
@@ -570,7 +612,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -746,7 +788,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,19 @@ The superuser comes back from sops on first start either way; the Authelia ident
 linked again from the user menu → My Profile → *Connect new social account*, since that link lives
 in the database this replaces.
 
+Mealie is an ordinary directory again, and the one place its restore differs is what is *in* the
+directory: alongside the recipes and their images sits the app secret it signs tokens with, so a
+restore keeps existing sessions valid rather than logging everyone out.
+
+```bash
+systemctl stop mealie
+
+rsync -a <pulled>/mealie/ /var/lib/mealie/
+chown -R mealie:mealie /var/lib/mealie && chmod 0700 /var/lib/mealie
+
+systemctl start mealie
+```
+
 Jellyfin's artwork is deliberately not in the backup — it re-fetches it — so expect the libraries
 to look bare until the first metadata scan finishes. Neither SABnzbd nor Recyclarr is in the
 backup either: the first holds a re-downloadable queue, the second a clone of the TRaSH guides and
@@ -391,6 +404,27 @@ exists to mint its token:
 
 To add a check later, edit `modules/server/gatus.nix` and deploy — there is no UI to click,
 which is the trade that keeps the monitor list in git and out of the backups.
+
+### Bringing up Mealie
+
+Mealie authenticates against Authelia over OIDC, and gates on LLDAP group membership. Neither the
+groups nor the first admin can come from this repo, so the first run is a short bootstrap — and
+step 4 is not optional:
+
+1. **LLDAP** (`https://ldap.home.guimbert.fr`) — create the groups `mealie-users` and
+   `mealie-admins`, and add yourself to both. Check the account has an email set: Mealie refuses
+   any OIDC login whose `email_verified` claim is absent, and Authelia sources both from LLDAP.
+2. `sops secrets/srv-01.yaml` and add a pair generated with
+   `authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72`:
+   - `autheliaOidcMealieClientSecret` — the plaintext, which `modules/server/mealie.nix` renders
+     into Mealie's environment file.
+   - `autheliaOidcMealieClientSecretDigest` — the digest, which `modules/server/authelia.nix`
+     reads.
+3. `just deploy srv-01`, open `https://mealie.home.guimbert.fr` and use **Login with Authelia**.
+   The account is created on the spot, with admin rights taken from the group claim.
+4. Settings → Users → **delete `changeme@example.com`**. Mealie seeds that account with the
+   password `MyPassword` and offers no way to configure it away, and this route carries no
+   Authelia middleware. It is reachable from the LAN only, but the window should be minutes.
 
 ### Managing Secrets
 

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -26,6 +26,7 @@
         grimmory
         shelfmark
         paperless
+        mealie
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/server/authelia.nix
+++ b/modules/server/authelia.nix
@@ -44,6 +44,7 @@
           autheliaOidcImmichClientSecretDigest = sopsConfig;
           autheliaOidcGrimmoryClientSecretDigest = sopsConfig;
           autheliaOidcPaperlessClientSecretDigest = sopsConfig;
+          autheliaOidcMealieClientSecretDigest = sopsConfig;
         };
       };
       services = {
@@ -244,6 +245,42 @@
                   # userinfo body and a signed JWT is not JSON. No
                   # `claims_policy`: allauth reads userinfo, not the ID token
                   # Grimmory needs one for.
+                }
+                {
+                  client_id = "mealie";
+                  client_name = "Mealie";
+                  client_secret = "{{ secret \"${config.sops.secrets.autheliaOidcMealieClientSecretDigest.path}\" }}";
+                  public = false;
+                  authorization_policy = "two_factor";
+                  consent_mode = "pre-configured";
+                  pre_configured_consent_duration = "1 year";
+                  # Required rather than permitted, as for Grimmory: Mealie's
+                  # authlib client always sends an S256 challenge.
+                  require_pkce = true;
+                  pkce_challenge_method = "S256";
+                  response_types = [ "code" ];
+                  grant_types = [ "authorization_code" ];
+                  id_token_signed_response_alg = "RS256";
+                  # The mirror image of Paperless's line: authlib picks basic
+                  # unless told otherwise, and a mismatch 401s at the token
+                  # exchange with nothing logged either side.
+                  token_endpoint_auth_method = "client_secret_basic";
+                  # Mealie builds this from its own BASE_URL plus `/login`, so it
+                  # has to match ./mealie.nix byte for byte.
+                  redirect_uris = [ "https://mealie.${constants.domain}/login" ];
+                  # `groups` because ./mealie.nix maps OIDC_ADMIN_GROUP onto the
+                  # claim; Mealie asks for the scope only when that is set.
+                  scopes = [
+                    "openid"
+                    "profile"
+                    "email"
+                    "groups"
+                  ];
+                  # Both omissions are load-bearing. No `claims_policy`: Mealie
+                  # reads the ID token *first* and falls back to userinfo, so
+                  # Grimmory's fix is unnecessary. No
+                  # `userinfo_signed_response_alg`: Immich's RS256 would hand that
+                  # fallback a JWT where it expects JSON, as it would Paperless.
                 }
               ];
               claims_policies.grimmory.id_token = [

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -44,6 +44,9 @@
         # Everything ./shelfmark.nix cannot express as an environment variable,
         # plus the users and their requests.
         "/var/lib/shelfmark"
+        # Recipes, their images, and the app secret Mealie signs tokens with —
+        # lose that and a restore invalidates every session it issued.
+        "/var/lib/mealie"
       ];
       # Not here on purpose: sabnzbd, whose state is a re-downloadable queue, and
       # recyclarr, whose directory is a clone of the TRaSH guides plus a config
@@ -66,6 +69,7 @@
         "${config.services.bazarr.dataDir}/db/bazarr.db"
         "${config.services.seerr.configDir}/db/db.sqlite3"
         "/var/lib/shelfmark/users.db"
+        "/var/lib/mealie/mealie.db"
       ];
 
       # Grimmory's library metadata, users and OIDC client. The only thing staged

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -233,6 +233,13 @@
                 name = "paperless";
                 path = "/accounts/login/";
               })
+              # Exempt for the same reason again. This path answers without a
+              # session, where `/` serves the frontend shell just as happily
+              # from an instance whose database is gone.
+              (mkHttps {
+                name = "mealie";
+                path = "/api/app/about";
+              })
               (mkHttps { name = "immich"; })
               (mkHttps {
                 name = "garage";

--- a/modules/server/mealie.nix
+++ b/modules/server/mealie.nix
@@ -1,0 +1,122 @@
+{ ... }:
+{
+  # Recipes and meal planning. Like ./paperless.nix and unlike ./grimmory.nix, an
+  # ordinary nixpkgs module: no image tag to pin, no Renovate entry, the weekly
+  # lockfile PR covers it.
+  nixos.modules.mealie =
+    {
+      config,
+      constants,
+      lib,
+      mkRouter,
+      ...
+    }:
+    let
+      port = 9000;
+    in
+    {
+      # DynamicUser is turned off below, so this account has to exist and keep the
+      # same id across boots. 359 is ./print-scan.nix's scanservjs.
+      users = {
+        users.mealie = {
+          isSystemUser = true;
+          group = "mealie";
+          uid = 360;
+        };
+        groups.mealie.gid = 360;
+      };
+
+      homepageTiles.Services = [
+        {
+          Mealie = {
+            icon = "mealie.png";
+            href = "https://mealie.${constants.domain}";
+            siteMonitor = "https://mealie.${constants.domain}";
+            description = "Recipes and meal planning";
+          };
+        }
+      ];
+
+      sops = {
+        # The plaintext half of the pair whose pbkdf2 digest ./authelia.nix reads,
+        # declared on the side that needs the real value — ./paperless.nix.
+        secrets.autheliaOidcMealieClientSecret.owner = "mealie";
+
+        # Not `settings` below: the module renders that into the unit's
+        # `Environment=`, which reaches the store and the journal, exactly as
+        # ./shelfmark.nix documents for its API keys.
+        templates.mealieEnvironment = {
+          owner = "mealie";
+          content = ''
+            OIDC_CLIENT_SECRET=${config.sops.placeholder.autheliaOidcMealieClientSecret}
+          '';
+        };
+      };
+
+      services = {
+        mealie = {
+          enable = true;
+          inherit port;
+          # The module defaults this to 0.0.0.0; Traefik is the only way in.
+          listenAddress = "127.0.0.1";
+          credentialsFile = config.sops.templates.mealieEnvironment.path;
+
+          # Every value here goes through `toString`, and Nix's `toString false`
+          # is the *empty string* — hence the quoted booleans.
+          settings = {
+            # Mealie derives its OIDC redirect URI from this plus `/login`, which
+            # ./authelia.nix registers byte for byte.
+            BASE_URL = "https://mealie.${constants.domain}";
+
+            # Its default, stated because it is what keeps account creation gated
+            # on the group below rather than on who can reach the port.
+            ALLOW_SIGNUP = "false";
+
+            OIDC_AUTH_ENABLED = "true";
+            OIDC_PROVIDER_NAME = "Authelia";
+            OIDC_CONFIGURATION_URL = "https://auth.${constants.domain}/.well-known/openid-configuration";
+            OIDC_CLIENT_ID = "mealie";
+            # So the group is the invite: there is no second list to maintain.
+            OIDC_SIGNUP_ENABLED = "true";
+            # Setting either of these is *also* what appends `groups` to the scope
+            # Mealie requests, so dropping them takes the claim with them. The
+            # LLDAP groups are created by hand — ../../README.md.
+            OIDC_USER_GROUP = "mealie-users";
+            OIDC_ADMIN_GROUP = "mealie-admins";
+            # Off for ./paperless.nix's reason: the local login is the way in when
+            # Authelia is the thing that is down.
+            OIDC_AUTO_REDIRECT = "false";
+          };
+        };
+
+        # `mkRouter`, not `mkAutheliaRouter`: Mealie has no proxy-header auth mode
+        # to delegate to the way the *arr do, and its REST API is a client no
+        # browser SSO round trip can serve.
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "mealie";
+          inherit port;
+        };
+      };
+
+      systemd.services.mealie.serviceConfig = {
+        # Same reason as ./lldap.nix and ./shelfmark.nix: a uid allocated per boot
+        # cannot own preserved state. It also moves the state out of
+        # /var/lib/private/mealie.
+        DynamicUser = lib.mkForce false;
+        User = "mealie";
+        Group = "mealie";
+        StateDirectoryMode = "0700";
+      };
+
+      # Holds the recipes and their images, and the app secret Mealie generates on
+      # first start and signs its tokens with.
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = "/var/lib/mealie";
+          user = "mealie";
+          group = "mealie";
+          mode = "0700";
+        }
+      ];
+    };
+}

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -36,6 +36,8 @@ grimmoryDbPassword: ENC[AES256_GCM,data:/QnIi7NifR2D/DmXPeXTvWOsnWyIrDmUgGe+ZaBC
 paperlessAdminPassword: ENC[AES256_GCM,data:eoMUzPb8G3v/9OBJCBV+3TwAJMb7GxeQe/OjMU2TiAA=,iv:PH7+RVeiehBP/siVKT85OO9oZ7W+ag9waNpjFu7zkC0=,tag:aCMOPnc/wQhNPABGfOKJBg==,type:str]
 autheliaOidcPaperlessClientSecret: ENC[AES256_GCM,data:9nsa77zVlTyspy3JqlGK35gUGzyRj9TQCay2dyQc0Xo7bSCB8pEPbP/7nTqncGtjw23SXqlCgL15PgQqVeIEk6YVtwzKRNuA,iv:vq97lOVx3xGAHF+nI4yiNNeUyGBFCaacJ68ETYvON9M=,tag:Mlmo3Hu+EvwbzWKeqq2sCg==,type:str]
 autheliaOidcPaperlessClientSecretDigest: ENC[AES256_GCM,data:eOV9s8qezywKYGwO+iNbNOtYGsVuL5VQCBhGlA4rfDJc4awKPvFEWMv1iG7U2IRSfuiU+bS9C1p2k7jvWl6nsEPmu0q9KNWjZcCOBQSSgZ/3x4yYvpiAmpwHe8xccI+HjvraFNykf+U56b0ivs0kKtiHEM27brOc/x5WfJ621s614RI=,iv:N0gidkRZcp9xPylkpCDqfq2fRIDbMtfevQlb3zU8oWk=,tag:zw7bkR87p1U6Ik8ERow/CQ==,type:str]
+autheliaOidcMealieClientSecret: ENC[AES256_GCM,data:CMYPB+0uEqElarvBlIfAKo4eQtQ+ubWZEn1gUFjJtdfsFNd9K8CoKpAsrp0eMqMk8kaZNsIiUoGMOsVtx1McTUNbLhqF/BVl,iv:q+NV3ngOSFyzDfrD1a2J3v8WY1eysvrygL2S4zsJ1V0=,tag:+80tIDD/uO+35wFTxs7MSA==,type:str]
+autheliaOidcMealieClientSecretDigest: ENC[AES256_GCM,data:/xcFwT7ehmkcxHS0ANyx6FwNWSmi8rfuN+vN6+r5CCmSgwRDRGZ5e0y/SFpMk7xOqRY8OhyQ7cT5iXJjOUGwgTd7J2ywy6vNaIuJdgygW9nlTEEBQfGYtgVOswol5JLqBTf63WjB6Byox7VdQbQDS1ut3XjW7bfY27lAFNg7DMEI1sA=,iv:KrRTLzkZl8GqxBD6O2tQR7eM2QZJTUpmCiUgB/oY5uE=,tag:bywR/D0b5K6VlctPJJJJ4g==,type:str]
 sops:
     age:
         - enc: |
@@ -47,8 +49,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-06T10:20:37Z"
-    mac: ENC[AES256_GCM,data:DCO0ORCfSmqH+VrVk6XL0imn4AL2+AQZ0I0p0vaMq5CzhtyFQ586nnk4zZI79y1Y6bYDDF96rtuHPBsHQLwiq8yCSWavthC03LR00CMrgIysrH6zqKQt8MK4Vb5ZiffE9Jq+aVc6OPeeSC6wDbFZR/Wc5fur+WkoaXKogc30Tfw=,iv:vHa2hW5MDCdhfUMPFuobl4x0MCCQ2yygYEh0eJxKRwA=,tag:jnbb84k6fIKy3oEINgLJyQ==,type:str]
+    lastmodified: "2026-08-06T15:46:25Z"
+    mac: ENC[AES256_GCM,data:bg8BBPX5UFuOEJL/GMxnF6SQb9vbshijsmSKBgEu9uwpm8uM26zswUExvEjvpKNYaR5aK2XYSj810HRwvLzKLyfRO1XYDSAhkTSjSOvijTVGjc85XQnovzUTxBjEvh4xi+6Aa9oVCq2gfvs9Tq4qiIpzZZ6E1IOWhQ2n/ECDwjw=,iv:EzASHbrUbKpUaWPiRskVnCXoxvwQaPkqPnl4etTf2FY=,tag:Lo8ItrekAvYcfN6j92WWNQ==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
An ordinary nixpkgs module (`services.mealie`), so the paperless shape
rather than the grimmory one: no image tag to pin and no Renovate entry.

SQLite rather than the PostgreSQL the module can bring up. `createLocally`
would reuse the cluster paperless starts, but /var/lib/postgresql is
preserved *in* paperless.nix, so mealie would silently depend on that
aspect being imported. As one file it falls into backup.nix's existing
online-backup loop instead.

`mkRouter`, not `mkAutheliaRouter`, joining Jellyfin, Jellyseerr, Grimmory
and Paperless: Mealie has no proxy-header auth mode to delegate to the way
the *arr do, and its REST API is a client no browser SSO round trip can
serve. It authenticates against Authelia over OIDC instead, gated on the
LLDAP groups mealie-users/mealie-admins — and setting either of those env
vars is also what makes Mealie ask for the `groups` scope at all.

The fourth OIDC client, and it matches none of the first three: it reads
the ID token *first* and falls back to userinfo, so it needs no
claims_policy where Grimmory does; and it states client_secret_basic,
the mirror image of Paperless's client_secret_post, because authlib picks
basic unless told otherwise.

DynamicUser forced off with uid/gid 360 pinned, for lldap.nix's reason —
a uid allocated per boot cannot own preserved state. The client secret
goes through a sops template as an EnvironmentFile, since `settings` is
rendered into the unit's Environment= and would reach the store and the
journal.

Note the two bootstrap steps in README.md: the LLDAP groups have to exist
before the first login, and the seeded changeme@example.com user has to be
deleted after it — Mealie hardcodes its password and offers no way to
configure it away.
