### PR TITLE
feat(srv-01): serve calendars and contacts with Radicale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,10 @@ Three ways in, because apps fall into three groups:
   Jellyfin OIDC plugin (`9p4/jellyfin-plugin-sso`) was archived upstream in May 2026 with no
   successor fork, and never completed the flow outside a browser anyway, so LDAP is the only
   credential its TV and mobile clients can use. That is now a live dependency rather than a
-  hypothetical one — see "Media on srv-01". Nothing else off-host currently binds `:636`; do not
-  remove LLDAP on that basis alone.
+  hypothetical one — see "Media on srv-01" — and Radicale is a second one, for the same reason on
+  different clients: CalDAV and CardDAV speak HTTP Basic, so DAVx5 and Thunderbird cannot complete
+  a browser SSO round trip either (see "Calendars and contacts on srv-01"). Nothing else off-host
+  currently binds `:636`; do not remove LLDAP on that basis alone.
 
 Passkeys are enabled (`webauthn.enable_passkey_login`). Authelia 4.39 counts a passkey as *one*
 factor, so it opens the `one_factor` forward-auth routes on its own, but not an OIDC client set
@@ -144,7 +146,7 @@ hand the plaintext to the app. Authelia refuses to start with an empty client li
 ### Backing up srv-01
 
 srv-01 pushes nothing. The `backup` aspect (`modules/server/backup.nix`) stages the lldap,
-authelia, *arr, Jellyfin, Shelfmark, Grimmory and Mealie state into `/var/backup/data` at 01:00, and the
+authelia, *arr, Jellyfin, Shelfmark, Grimmory, Mealie and Radicale state into `/var/backup/data` at 01:00, and the
 TrueNAS *pulls* it over SFTP, so srv-01 holds no credential that reaches its own backups. The
 media is never in scope — it lives on the NAS to begin with — and neither is Jellyfin's metadata
 cache, which is artwork it re-fetches on demand. Retention is the NAS's periodic
@@ -152,7 +154,7 @@ snapshot task, not anything here, and `/var/lib/traefik` is deliberately out of 
 `acme.json` holds the wildcard cert's private key, which Cloudflare DNS re-issues for free.
 Restores are in README.md.
 
-Everything staged is sqlite through the online-backup API, **except Grimmory**, whose library
+Every database staged is sqlite through the online-backup API, **except Grimmory**, whose library
 metadata, users and OIDC client are in MariaDB and go through `mariadb-dump --single-transaction`.
 That dump is also the only backup of configuration this repo cannot rebuild — see "Books on
 srv-01".
@@ -524,6 +526,56 @@ API is a client a browser SSO round trip cannot serve. Access is gated instead o
 take the claim with them. `OIDC_AUTO_REDIRECT` stays off for Paperless's reason: the local login is
 the way in when Authelia is the thing that is down.
 
+### Calendars and contacts on srv-01
+
+`radicale` (`modules/server/radicale.nix`) — CalDAV and CardDAV. The `paperless`/`mealie` shape
+again (`services.radicale`, an ordinary nixpkgs module), and the only aspect here whose backup
+needs no dump of any kind: collections are plain `.ics`/`.vcf` files written by atomic rename, so
+`backup.nix` stages `/var/lib/radicale` with the same rsync as everything else.
+
+**It authenticates against LLDAP, and that is the second live reason LLDAP stays.** CalDAV and
+CardDAV clients send HTTP Basic; DAVx5 and Thunderbird can no more complete a browser SSO round
+trip than a TV can, so `auth.type = "ldap"` and the route is `mkRouter` — joining Jellyfin,
+Jellyseerr, Grimmory, Paperless and Mealie. Access is gated on the LLDAP group `radicale-users`
+through a `memberOf` clause in `ldap_filter`, the way Mealie gates on `mealie-users`. Bootstrap
+(the group, and the read-only bind account LLDAP requires because it refuses anonymous search) is
+in README.md, "Bringing up Radicale".
+
+Four things fail misleadingly:
+
+- **`server.hosts` is deliberately not set.** nixpkgs derives `bindLocalhost` from that key being
+  *absent* and keys `IPAddressAllow = "localhost"` / `IPAddressDeny = "any"` off it, so declaring
+  it — even to restate the default — silently drops the filter and buys back only a systemd block
+  restoring it. The `port` in the `let` therefore *matches* Radicale's default rather than
+  asserting it; it exists for `mkRouter`, and the comment on it says so.
+- **`ldap_base` must be `ou=people,…`, not the root DN.** LLDAP evaluates `memberOf` as a *person*
+  attribute; a search based anywhere else logs `Ignoring unknown group attribute "memberof" in
+  filter`, matches nothing, and surfaces only as "no unique DN found" and a 401 for every user. The
+  filter value must also be the group's full DN, not `cn=radicale-users` alone. `ldap_filter` is
+  `str.format`ted for `{0}`, so any other brace in it raises at login time.
+- **`ldap_user_attribute = "uid"` pins the collection path.** It is what Radicale uses as the login
+  once the bind succeeds, and `rights.type = "owner_only"` derives `/<user>/` from that. Without
+  it the path is whatever the client typed, so a differently-cased login silently gets a second,
+  empty tree.
+- **`auth.type` is not optional.** Radicale 3.5.0 changed its default from `none` to `denyall`, and
+  the nixpkgs module asserts the key is set rather than letting a host come up refusing everyone.
+
+`cache_logins` is on because Radicale otherwise binds to LDAP *twice per request* and DAV clients
+poll; the expiry defaults (15s success, 90s failure) are left alone so removing someone from the
+group still takes effect in seconds.
+
+**The Gatus check is a `PROPFIND`, and a GET cannot replace it.** `GET /` 302s to `/.web` — the
+login UI, which Radicale serves *unauthenticated* — so a GET check follows the redirect and records
+that page's 200 without ever touching auth or a collection, the same trap `mkAutheliaHttps` avoids
+by refusing its redirect. PROPFIND is what the DAV clients actually issue and what `owner_only`
+refuses to an empty user, so asserting **401** on it says Radicale is serving *and* enforcing,
+where a 200 or a 207 would mean auth had fallen away. (`/.web` being public is a login form, not an
+exposure: no collection is readable without credentials.)
+
+The uid is pinned (361) for `lldap.nix`'s reason — nixpkgs has allocated radicale's
+dynamically since 2021 — and the sops secret is reached by `owner` rather than a supplementary
+group, because the module's unit runs with `PrivateUsers`.
+
 ### Formatting and Linting
 
 ```bash
@@ -604,7 +656,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", and Mealie in "Recipes on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", and Radicale in "Calendars and contacts on srv-01"
 
 ### Module Organization
 
@@ -612,7 +664,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -788,7 +840,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,21 @@ chown -R mealie:mealie /var/lib/mealie && chmod 0700 /var/lib/mealie
 systemctl start mealie
 ```
 
+Radicale is the simplest restore here, and the only one with no database at all — the collections
+are plain `.ics` and `.vcf` files, and the accounts that own them live in LLDAP, restored above:
+
+```bash
+systemctl stop radicale
+
+rsync -a <pulled>/radicale/ /var/lib/radicale/
+chown -R radicale:radicale /var/lib/radicale && chmod 0750 /var/lib/radicale
+
+systemctl start radicale
+```
+
+`.Radicale.cache` comes back with it and is harmless; Radicale rebuilds it if it is stale or
+missing. The collection paths are LLDAP `uid`s, so they line up as long as the same accounts exist.
+
 Jellyfin's artwork is deliberately not in the backup — it re-fetches it — so expect the libraries
 to look bare until the first metadata scan finishes. Neither SABnzbd nor Recyclarr is in the
 backup either: the first holds a re-downloadable queue, the second a clone of the TRaSH guides and
@@ -425,6 +440,28 @@ step 4 is not optional:
 4. Settings → Users → **delete `changeme@example.com`**. Mealie seeds that account with the
    password `MyPassword` and offers no way to configure it away, and this route carries no
    Authelia middleware. It is reachable from the LAN only, but the window should be minutes.
+
+### Bringing up Radicale
+
+Radicale authenticates its own clients against LLDAP, because CalDAV and CardDAV clients send
+HTTP Basic and cannot complete a browser SSO round trip. Neither the group it gates on nor the
+account it binds with can come from this repo, so the first run is a short bootstrap:
+
+1. **LLDAP** (`https://ldap.home.guimbert.fr`) — create the group `radicale-users` and add
+   yourself. Then create a user `radicale` with a generated password and add it to
+   `lldap_strict_readonly`: LLDAP refuses anonymous search, and Radicale always searches for a
+   user's DN before binding as them, so the read-only account is what makes any login work at
+   all.
+2. `sops secrets/srv-01.yaml` and add `radicaleLdapPassword` — that account's password, which
+   `modules/server/radicale.nix` hands to Radicale as `ldap_secret_file`.
+3. `just deploy srv-01`, then open `https://radicale.home.guimbert.fr` and log in with your
+   **LLDAP** credentials (not an Authelia session — this route carries no middleware). Create a
+   calendar and an address book from the web UI; Radicale creates no collections on its own.
+4. Point clients at `https://radicale.home.guimbert.fr` — DAVx5 and Thunderbird discover the
+   collections through `/.well-known/{caldav,carddav}`, which Radicale redirects to `/`.
+
+Access is the group, so revoking someone is removing them from `radicale-users`; it takes
+effect within the 15 seconds `cache_logins` holds a successful login for.
 
 ### Managing Secrets
 

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -27,6 +27,7 @@
         shelfmark
         paperless
         mealie
+        radicale
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -47,6 +47,10 @@
         # Recipes, their images, and the app secret Mealie signs tokens with —
         # lose that and a restore invalidates every session it issued.
         "/var/lib/mealie"
+        # The one entry needing no dump of any kind: ./radicale.nix stores
+        # calendars and address books as plain .ics/.vcf files written by atomic
+        # rename, so the rsync below is already consistent.
+        "/var/lib/radicale"
       ];
       # Not here on purpose: sabnzbd, whose state is a re-downloadable queue, and
       # recyclarr, whose directory is a clone of the TRaSH guides plus a config

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -31,6 +31,7 @@
           path ? "",
           status ? 200,
           conditions ? [ ],
+          method ? null,
         }:
         {
           inherit name;
@@ -38,7 +39,8 @@
           url = "https://${subdomain}.${constants.domain}${path}";
           interval = "2m";
           conditions = [ "[STATUS] == ${toString status}" ] ++ conditions;
-        };
+        }
+        // lib.optionalAttrs (method != null) { inherit method; };
 
       # A route behind the authelia middleware never reaches its backend, and what
       # the middleware answers depends on the request's Accept header: a client
@@ -239,6 +241,19 @@
               (mkHttps {
                 name = "mealie";
                 path = "/api/app/about";
+              })
+              # Exempt from the middleware too — its clients speak Basic auth
+              # against LLDAP — so this has to reach Radicale's own auth. A GET
+              # cannot: `/` redirects to `/.web`, the login UI, which Radicale
+              # serves unauthenticated, and following that records its 200 the
+              # same way ./homepage.nix's portal would. PROPFIND is the method
+              # the DAV clients actually use, and it is refused without
+              # credentials, so 401 here says Radicale is serving *and*
+              # enforcing where a 200 or a 207 would mean auth had fallen away.
+              (mkHttps {
+                name = "radicale";
+                method = "PROPFIND";
+                status = 401;
               })
               (mkHttps { name = "immich"; })
               (mkHttps {

--- a/modules/server/radicale.nix
+++ b/modules/server/radicale.nix
@@ -1,0 +1,108 @@
+{ ... }:
+{
+  # Calendars and contacts, authenticating against LLDAP rather than sitting
+  # behind the authelia middleware: CalDAV and CardDAV clients send HTTP Basic
+  # and cannot complete a browser SSO round trip — ./jellyfin.nix's argument on
+  # different clients. An ordinary nixpkgs module, so the ./mealie.nix shape
+  # rather than the ./grimmory.nix one.
+  nixos.modules.radicale =
+    {
+      config,
+      constants,
+      mkRouter,
+      ...
+    }:
+    let
+      # Radicale's own default, matched rather than restated: declaring
+      # `server.hosts` is what turns off the module's IPAddressAllow=localhost /
+      # IPAddressDeny=any, which it keys off that option being *absent*.
+      port = 5232;
+    in
+    {
+      # nixpkgs allocates radicale's uid dynamically, so it is pinned for
+      # ./lldap.nix's reason: a uid allocated per boot cannot own preserved
+      # state. 360 is ./mealie.nix.
+      users = {
+        users.radicale.uid = 361;
+        groups.radicale.gid = 361;
+      };
+
+      homepageTiles.Services = [
+        {
+          Radicale = {
+            icon = "radicale.png";
+            href = "https://radicale.${constants.domain}";
+            siteMonitor = "https://radicale.${constants.domain}";
+            description = "Calendars and contacts";
+          };
+        }
+      ];
+
+      # `owner` rather than a supplementary group: the module's unit runs with
+      # `PrivateUsers`, which ./jellyfin.nix explains costs such a group
+      # everything.
+      sops.secrets.radicaleLdapPassword.owner = "radicale";
+
+      services = {
+        radicale = {
+          enable = true;
+          settings = {
+            auth = {
+              # Stated because Radicale 3.5.0 changed the default from `none` to
+              # `denyall`, and the module asserts the key rather than let a host
+              # come up refusing everyone.
+              type = "ldap";
+              ldap_uri = "ldap://127.0.0.1:3890";
+              # `ou=people`, not the root DN: LLDAP evaluates `memberOf` as a
+              # *person* attribute, and a search based anywhere else logs
+              # `Ignoring unknown group attribute "memberof" in filter` and
+              # matches nothing — surfacing only as a 401 for every user.
+              ldap_base = "ou=people,dc=guimbert,dc=fr";
+              # LLDAP refuses anonymous search and Radicale always looks up the
+              # user's DN before binding as them, so this account is required.
+              # Created by hand in `lldap_strict_readonly` — ../../README.md.
+              ldap_reader_dn = "uid=radicale,ou=people,dc=guimbert,dc=fr";
+              ldap_secret_file = config.sops.secrets.radicaleLdapPassword.path;
+              # Gates access on a group the way ./mealie.nix does. The value has
+              # to be the group's full DN; `cn=radicale-users` alone matches
+              # nothing.
+              ldap_filter = "(&(objectClass=person)(uid={0})(memberOf=cn=radicale-users,ou=groups,dc=guimbert,dc=fr))";
+              # The login Radicale keeps once the bind succeeds, and so what
+              # fixes the collection path under `owner_only`. Without it the path
+              # is whatever the client typed, and a differently-cased login gets
+              # a second, empty tree.
+              ldap_user_attribute = "uid";
+              # Two LDAP binds per request otherwise, and DAV clients poll. The
+              # expiry defaults are left alone (15s success, 90s failure), so
+              # dropping someone from the group still takes effect in seconds.
+              cache_logins = true;
+            };
+
+            # Radicale's default, stated because ./gatus.nix's 401 rests on it
+            # refusing an empty user — the `/.web` login UI is served without
+            # credentials, so this is what keeps the collections behind them.
+            rights.type = "owner_only";
+          };
+        };
+
+        # `mkRouter`, not `mkAutheliaRouter` — forward-auth in front of a DAV
+        # endpoint would lock out every client this exists for.
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "radicale";
+          inherit port;
+        };
+      };
+
+      # 0750 matches the module's StateDirectoryMode, and its
+      # `StateDirectory=radicale/collections` creates the child at service start
+      # — so this is immune to the tmpfiles race ../../CLAUDE.md documents.
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = "/var/lib/radicale";
+          user = "radicale";
+          group = "radicale";
+          mode = "0750";
+        }
+      ];
+    };
+}

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -38,6 +38,7 @@ autheliaOidcPaperlessClientSecret: ENC[AES256_GCM,data:9nsa77zVlTyspy3JqlGK35gUG
 autheliaOidcPaperlessClientSecretDigest: ENC[AES256_GCM,data:eOV9s8qezywKYGwO+iNbNOtYGsVuL5VQCBhGlA4rfDJc4awKPvFEWMv1iG7U2IRSfuiU+bS9C1p2k7jvWl6nsEPmu0q9KNWjZcCOBQSSgZ/3x4yYvpiAmpwHe8xccI+HjvraFNykf+U56b0ivs0kKtiHEM27brOc/x5WfJ621s614RI=,iv:N0gidkRZcp9xPylkpCDqfq2fRIDbMtfevQlb3zU8oWk=,tag:zw7bkR87p1U6Ik8ERow/CQ==,type:str]
 autheliaOidcMealieClientSecret: ENC[AES256_GCM,data:CMYPB+0uEqElarvBlIfAKo4eQtQ+ubWZEn1gUFjJtdfsFNd9K8CoKpAsrp0eMqMk8kaZNsIiUoGMOsVtx1McTUNbLhqF/BVl,iv:q+NV3ngOSFyzDfrD1a2J3v8WY1eysvrygL2S4zsJ1V0=,tag:+80tIDD/uO+35wFTxs7MSA==,type:str]
 autheliaOidcMealieClientSecretDigest: ENC[AES256_GCM,data:/xcFwT7ehmkcxHS0ANyx6FwNWSmi8rfuN+vN6+r5CCmSgwRDRGZ5e0y/SFpMk7xOqRY8OhyQ7cT5iXJjOUGwgTd7J2ywy6vNaIuJdgygW9nlTEEBQfGYtgVOswol5JLqBTf63WjB6Byox7VdQbQDS1ut3XjW7bfY27lAFNg7DMEI1sA=,iv:KrRTLzkZl8GqxBD6O2tQR7eM2QZJTUpmCiUgB/oY5uE=,tag:bywR/D0b5K6VlctPJJJJ4g==,type:str]
+radicaleLdapPassword: ENC[AES256_GCM,data:NQYWqI9Urg2/PBx9qVryCa4eWOO5y7fcx9eTxOAntWM=,iv:jLf/vf805kI4d7mTQly0Cu4vrnLhifvgTVT8AT/BpMI=,tag:pBrH+68l8iW+kDYq65T6Gw==,type:str]
 sops:
     age:
         - enc: |
@@ -49,8 +50,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-06T15:46:25Z"
-    mac: ENC[AES256_GCM,data:bg8BBPX5UFuOEJL/GMxnF6SQb9vbshijsmSKBgEu9uwpm8uM26zswUExvEjvpKNYaR5aK2XYSj810HRwvLzKLyfRO1XYDSAhkTSjSOvijTVGjc85XQnovzUTxBjEvh4xi+6Aa9oVCq2gfvs9Tq4qiIpzZZ6E1IOWhQ2n/ECDwjw=,iv:EzASHbrUbKpUaWPiRskVnCXoxvwQaPkqPnl4etTf2FY=,tag:Lo8ItrekAvYcfN6j92WWNQ==,type:str]
+    lastmodified: "2026-08-06T16:29:25Z"
+    mac: ENC[AES256_GCM,data:EnenLD08wQbk4gmhBuJ+VjRkeFpmuMPVRKP9l3t+3m3BAliumUdtY42IQvkBSk3yZ3uEOp+mgeqnsqKLfUGFsn+dB8MbzQeJxsYo85UyiORcYebaIZ7Hi+UQwOWfP6SuKq3HMm2aRr3Z+dhv60iv6RVlMCKO2d/FXX3xCg0lQes=,iv:LkE0BTNuwuNnBsprunzfhouRcGmbdXk0qXv5WFUS9zM=,tag:6JSeQRrVImodiBf1e54eEQ==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
Calendars and address books had nowhere to live: everything on this host
was media, books, paperwork or recipes. Radicale fills that, and like
paperless and mealie it is an ordinary nixpkgs module rather than the
grimmory shape — no image tag to pin, no Renovate customManager, the
weekly lockfile PR covers it.

It authenticates against LLDAP over its own `auth.type = ldap`, so the
route is `mkRouter` and not `mkAutheliaRouter`. CalDAV and CardDAV clients
send HTTP Basic and can no more complete a browser SSO round trip than a
TV can, which is jellyfin.nix's argument applied to different clients —
and makes LLDAP a second live dependency rather than a hypothetical one.
Access is gated on the LLDAP group radicale-users through a memberOf
clause, the way mealie gates on mealie-users. That clause only works
against ou=people: LLDAP evaluates memberOf as a *person* attribute, and
a search based anywhere else matches nothing and surfaces only as a 401
for every user. `ldap_user_attribute` is what pins the collection path
under owner_only — without it the path is whatever the client typed, so a
differently-cased login gets a second, empty tree.

`server.hosts` is deliberately not set. The nixpkgs module derives
`bindLocalhost` from that key being *absent* and keys IPAddressAllow=
localhost / IPAddressDeny=any off it, so declaring it — even to restate
Radicale's own default — silently drops the filter and buys back only a
systemd block restoring it. The port in the `let` therefore matches that
default rather than asserting it; it exists for mkRouter.

uid/gid 361 pinned for lldap.nix's reason, since nixpkgs allocates
radicale's dynamically and a uid allocated per boot cannot own preserved
state. The bind password is reached by sops `owner` rather than a
supplementary group, because the module's unit runs with PrivateUsers.

backup.nix gains the one entry needing no dump of any kind: collections
are plain .ics/.vcf files written by atomic rename, so the existing rsync
is already consistent.

The gatus check is a PROPFIND, and a GET cannot replace it. `GET /` 302s
to /.web — the login UI, which Radicale serves unauthenticated — so a GET
follows the redirect and records that page's 200 without touching auth or
a collection, the same trap mkAutheliaHttps avoids by refusing its
redirect. PROPFIND is what the DAV clients issue and what owner_only
refuses to an empty user, so 401 says Radicale is serving *and* enforcing
where a 200 or a 207 would mean auth had fallen away. `method` joins
mkHttps as an optional argument, gated the way mkRouter gates middlewares.

Note the bootstrap in README.md: neither the radicale-users group nor the
read-only bind account can come from this repo, and LLDAP refuses
anonymous search, so every login fails until both exist.
