### PR TITLE
feat(srv-01): sync Obsidian vaults with CouchDB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,6 +576,87 @@ The uid is pinned (361) for `lldap.nix`'s reason — nixpkgs has allocated radic
 dynamically since 2021 — and the sops secret is reached by `owner` rather than a supplementary
 group, because the module's unit runs with `PrivateUsers`.
 
+### Obsidian sync on srv-01
+
+`couchdb` (`modules/server/couchdb.nix`) — the remote database the Obsidian **Self-hosted
+LiveSync** plugin replicates a vault through. The `paperless`/`mealie`/`radicale` shape
+(`services.couchdb`, an ordinary nixpkgs module), and `mkRouter` rather than `mkAutheliaRouter`,
+joining Jellyfin, Jellyseerr, Grimmory, Paperless, Mealie and Radicale: a phone's webview cannot
+complete a browser SSO round trip, and replication is a REST client besides.
+
+**It is the one service here that cannot delegate its auth anywhere.** CouchDB speaks no LDAP, so
+LLDAP is not an option the way it is for Radicale, and the credential is local to CouchDB. What
+that is made to cost as little as possible: sops holds a **server admin** (`couchdb-admin`), used
+only to bootstrap and to maintain, and the account the plugin carries is a **non-admin `_users`
+account** granted `member` on the vault's database through an `obsidian-livesync` *role* — created
+by hand, since neither it nor the database can come from Nix (README.md, "Bringing up CouchDB").
+Granting by role rather than by name is what keeps a second vault from needing the `_security` doc
+edited; `members` with both `names` and `roles` empty would open the database to every
+authenticated user, so the role is load-bearing, not decoration. One account per **vault**, not per
+device — every device on a vault targets the same database, so per-device accounts would be members
+of the same database with identical rights.
+
+The plugin tolerates that, but two of its flows do not, and both fail as a bare 403:
+
+- **"Check and fix CouchDB issues"** reads `/_node/_local/_config`, which is server-admin only
+  (upstream issue #988). That is *wanted* here: the "fix" button writes `local.ini`, which outranks
+  the generated config — see below.
+- **"Rebuild everything" / reset-remote** does `DELETE` then `PUT` on the bare database name, which
+  `chttpd_auth_request.erl` gates on server admin. Paste the admin credential in for that one
+  operation.
+
+Routine compaction needs neither: smoosh's `db_channels` default compacts on its own.
+
+Four things fail misleadingly:
+
+- **The generated config is writable, the `sabnzbd.nix` situation.** The module passes
+  `-couch_ini default.ini <store ini> <the sops one> /var/lib/couchdb/local.ini`, and CouchDB
+  persists every runtime change to the **last** of those. So a Fauxton edit outranks the Nix file
+  from then on, and a key *removed* from Nix is not removed from `local.ini`. Deleting
+  `/var/lib/couchdb/local.ini` is the escape hatch; it is regenerated. The same fact makes
+  **rotating `couchdbAdminPassword` in sops a no-op on its own**: CouchDB hashes the cleartext into
+  `local.ini` on first start, and the merged view then shows only the hash. Rotation is edit sops,
+  delete `local.ini`, restart.
+- **`require_valid_user` and `require_valid_user_except_for_up` are both set.** Neither implies the
+  other: `chttpd_auth.erl` gates every other path on `RequireValidUser orelse
+  RequireValidUserExceptUp` and `/_up` on `RequireValidUser andalso not RequireValidUserExceptUp`.
+  Dropping the second closes `/_up` and the Gatus check goes permanently red; dropping the first
+  changes nothing, because the second already covers it.
+- **CORS survives `require_valid_user` only because of ordering.** `chttpd.erl` answers the
+  preflight *before* authenticating, so the credential-less `OPTIONS` a webview sends is not met
+  with a 401. That is why no Traefik CORS middleware is wired in front of this route — a second
+  `Access-Control-Allow-Origin` would make the browser reject the response outright.
+- **The plugin's remote URI must be `https://`, and getting that wrong looks exactly like a CORS
+  misconfiguration.** Traefik's `web` entrypoint 308-redirects to `websecure`, and the CORS spec
+  forbids following a redirect on a *preflight* — so a `http://` URI is killed by the browser with
+  `Redirect is not allowed for a preflight request` before CouchDB is ever reached, while
+  Obsidian's `requestUrl` API follows the redirect happily. That is what produces the plugin's
+  "the request was successful by API. But the native fetch API failed! Please check CORS settings"
+  warning, and no amount of `[cors]` tuning fixes it. This applies to every route on this host, but
+  only here does a client speak CORS. Check the scheme in the console error *first*; the origin and
+  header theories are much more expensive to chase.
+- **Four keys upstream's provisioning script sets are deliberately absent**, each checked against
+  couchdb 3.5.1's source: `chttpd.max_http_request_size` is already the code default;
+  `chttpd_auth.require_valid_user` is never read (both call sites go through
+  `get_chttpd_config_boolean`, which is `[chttpd]` falling back to `[httpd]`);
+  `httpd.WWW-Authenticate` only changes the realm string, which `require_valid_user` already emits;
+  and `cors.headers`/`cors.methods` left unset yield `chttpd_cors.erl`'s built-in lists, which
+  cover everything the plugin sends — pouchdb sets only `Accept`, `Authorization` and
+  `Content-Type`. Stating either **replaces** the built-in list rather than extending it, so the
+  short list the older upstream docs give would *narrow* it and drop `content-length`,
+  `destination`, `if-match` and `x-couch-full-commit`. That matters if a custom header is ever
+  configured in the plugin: it has to be added, and the value then has to be the whole built-in
+  list plus that header. CouchDB does not **reject** a preflight naming a header outside the list —
+  it declines to handle the preflight at all, falls through to the normal request path, and
+  `require_valid_user` answers 401 with no `Access-Control-Allow-Headers`, so one unknown header
+  poisons the whole preflight.
+
+`backup.nix` stages `/var/lib/couchdb` with a plain rsync and no dump of any kind: the file format
+is append-only, so upstream's own backup docs bless a copy taken while CouchDB is serving, and the
+one ordering rule they give — secondary indexes before the databases — falls out of rsync's sorted
+walk, since `.shards/` precedes `shards/`. The uid is *not* pinned, unlike every sibling here:
+nixpkgs gives couchdb a static id (106).
+
 ### Formatting and Linting
 
 ```bash
@@ -656,7 +737,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", and Radicale in "Calendars and contacts on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", and CouchDB in "Obsidian sync on srv-01"
 
 ### Module Organization
 
@@ -664,7 +745,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -840,7 +921,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,25 @@ systemctl start radicale
 `.Radicale.cache` comes back with it and is harmless; Radicale rebuilds it if it is stale or
 missing. The collection paths are LLDAP `uid`s, so they line up as long as the same accounts exist.
 
+CouchDB is an ordinary directory too, and needs no dump either — its file format is append-only,
+so the nightly copy is valid even though it was taken while CouchDB was serving:
+
+```bash
+systemctl stop couchdb
+
+rsync -a <pulled>/couchdb/ /var/lib/couchdb/
+chown -R couchdb:couchdb /var/lib/couchdb && chmod 0750 /var/lib/couchdb
+
+systemctl start couchdb
+```
+
+What comes back is the vaults, the `_users` accounts the Obsidian clients authenticate with and
+each database's `_security` doc — none of which this repo can reproduce. `local.ini` and
+`.erlang.cookie` come back with it: the cookie is harmless on a single node, but `local.ini`
+carries the *hashed* admin password as it was, and outranks the sops one. If `couchdbAdminPassword`
+has changed since the backup, `rm /var/lib/couchdb/local.ini` before starting and CouchDB will
+re-hash from sops.
+
 Jellyfin's artwork is deliberately not in the backup — it re-fetches it — so expect the libraries
 to look bare until the first metadata scan finishes. Neither SABnzbd nor Recyclarr is in the
 backup either: the first holds a re-downloadable queue, the second a clone of the TRaSH guides and
@@ -462,6 +481,65 @@ account it binds with can come from this repo, so the first run is a short boots
 
 Access is the group, so revoking someone is removing them from `radicale-users`; it takes
 effect within the 15 seconds `cache_logins` holds a successful login for.
+
+### Bringing up CouchDB
+
+CouchDB exists for one thing: the remote database the Obsidian **Self-hosted LiveSync** plugin
+replicates a vault through. It has no LDAP of any kind, so unlike Radicale it cannot delegate to
+LLDAP — the credential is local to CouchDB. `modules/server/couchdb.nix` declares the server
+config and a **server admin** from sops; the account the plugin carries is a **non-admin** one
+created here, so a credential sitting in plaintext on a phone cannot rewrite the server's
+configuration or delete the database.
+
+`couchdbAdminPassword` is already in `secrets/srv-01.yaml`; read it back with
+`sops -d secrets/srv-01.yaml`. Then, after `just deploy srv-01`:
+
+1. Create the vault's database. `PUT /<db>` is server-admin only, which is exactly why the
+   plugin's account cannot do it:
+   ```bash
+   curl -su couchdb-admin:<admin-pw> -X PUT https://couchdb.home.guimbert.fr/<vault>
+   ```
+2. Create the account the clients will use. The password is sent in the clear and CouchDB hashes
+   it on save:
+   ```bash
+   curl -su couchdb-admin:<admin-pw> -X PUT \
+     https://couchdb.home.guimbert.fr/_users/org.couchdb.user:<name> \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"<name>","password":"<pw>","roles":["obsidian-livesync"],"type":"user"}'
+   ```
+3. Grant it by **role**, not by name, so a second vault later needs no edit to this document:
+   ```bash
+   curl -su couchdb-admin:<admin-pw> -X PUT \
+     https://couchdb.home.guimbert.fr/<vault>/_security \
+     -H 'Content-Type: application/json' \
+     -d '{"admins":{"names":[],"roles":[]},"members":{"names":[],"roles":["obsidian-livesync"]}}'
+   ```
+   `members` with *both* lists empty would make the database readable by every authenticated user;
+   the role is what prevents that.
+4. In Obsidian, install **Self-hosted LiveSync**, pick manual setup, and enter
+   `https://couchdb.home.guimbert.fr`, the account from step 2 and the database from step 1.
+   The **`https://` is load-bearing**: Traefik 308-redirects `http://`, and a CORS preflight may
+   not follow a redirect, so an `http://` URI fails with *"the request was successful by API. But
+   the native fetch API failed! Please check CORS settings"* — which sends you hunting through
+   `[cors]` for a problem that is not there. **Skip "Check and fix CouchDB issues"** — see below.
+   Generate a Setup URI on that device and import it on the others.
+
+**One account per vault, not per device.** Every device on a vault must point at the same
+database, and a database's grant is its `_security` doc, so per-device accounts would all be
+members of the same database with identical rights — no isolation, three Setup URIs to mint. A
+*second vault* is what justifies a second account: it is a second database, and step 2's role
+already covers it.
+
+Two things the non-admin account cannot do, both by design:
+
+- **"Check and fix CouchDB issues"** (in the setup wizard and the settings pane) reads
+  `/_node/_local/_config`, which is admin-only, and returns 403. Nothing here needs it: those
+  settings are declared in `modules/server/couchdb.nix`, and the "fix" button would write them to
+  `/var/lib/couchdb/local.ini`, which outranks the generated config from then on.
+- **"Rebuild everything" / reset-remote** deletes and recreates the database, also admin-only.
+  Paste the admin credential into the plugin for that one operation, then put the account back.
+
+Routine compaction needs neither: CouchDB's smoosh daemon compacts on its own by default.
 
 ### Managing Secrets
 

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -28,6 +28,7 @@
         paperless
         mealie
         radicale
+        couchdb
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -51,6 +51,12 @@
         # calendars and address books as plain .ics/.vcf files written by atomic
         # rename, so the rsync below is already consistent.
         "/var/lib/radicale"
+        # The Obsidian vaults, their `_users` accounts and each database's
+        # `_security` doc. Needs no dump either: the file format is append-only,
+        # so upstream blesses a copy taken while CouchDB is serving, and their one
+        # ordering rule — secondary indexes first — falls out of rsync's sorted
+        # walk, since `.shards/` precedes `shards/`.
+        "/var/lib/couchdb"
       ];
       # Not here on purpose: sabnzbd, whose state is a re-downloadable queue, and
       # recyclarr, whose directory is a clone of the TRaSH guides plus a config

--- a/modules/server/couchdb.nix
+++ b/modules/server/couchdb.nix
@@ -1,0 +1,123 @@
+{ ... }:
+{
+  # CouchDB, serving one thing: the remote database the Obsidian Self-hosted
+  # LiveSync plugin replicates a vault through. Like ./paperless.nix and
+  # ./mealie.nix and unlike ./grimmory.nix, an ordinary nixpkgs module — no image
+  # tag to pin, no Renovate entry, the weekly lockfile PR covers it.
+  nixos.modules.couchdb =
+    {
+      config,
+      constants,
+      mkRouter,
+      ...
+    }:
+    let
+      port = 5984;
+    in
+    {
+      homepageTiles.Services = [
+        {
+          CouchDB = {
+            icon = "couchdb.png";
+            href = "https://couchdb.${constants.domain}/_utils/";
+            # `/` answers 401 under require_valid_user below, so the tile would
+            # sit permanently red. /_up is the one path left open.
+            siteMonitor = "https://couchdb.${constants.domain}/_up";
+            description = "Obsidian LiveSync";
+          };
+        }
+      ];
+
+      sops = {
+        secrets.couchdbAdminPassword = { };
+
+        # The *server* admin, used only to bootstrap and to maintain — what the
+        # plugin carries is a non-admin `_users` account created by hand
+        # (../../README.md, "Bringing up CouchDB"). Not `adminPass`, which the
+        # module renders into an ini in the *store*: the leak ./mealie.nix and
+        # ./shelfmark.nix avoid for their own secrets.
+        templates.couchdbAdmins = {
+          owner = "couchdb";
+          content = ''
+            [admins]
+            couchdb-admin = ${config.sops.placeholder.couchdbAdminPassword}
+          '';
+        };
+      };
+
+      services = {
+        couchdb = {
+          enable = true;
+          inherit port;
+          extraConfigFiles = [ config.sops.templates.couchdbAdmins.path ];
+
+          # Generated but *writable*, the ./sabnzbd.nix shape. The module passes
+          # `-couch_ini default.ini <this> <the sops one> /var/lib/couchdb/local.ini`
+          # and CouchDB persists runtime changes to the *last* of those, so a
+          # Fauxton edit outranks this from then on and a key removed here is not
+          # removed from local.ini. Deleting local.ini is the escape hatch.
+          extraConfig = {
+            couchdb = {
+              # Creates _users and _replicator at startup, so no /_cluster_setup.
+              single_node = true;
+              # LiveSync's requirement; CouchDB's default is 8 MB.
+              max_document_size = 50000000;
+            };
+
+            chttpd = {
+              # CouchDB speaks no LDAP, so unlike ./radicale.nix this cannot
+              # delegate to ./lldap.nix — the credential is local to CouchDB.
+              require_valid_user = true;
+              # Reopens /_up alone, for ./gatus.nix. Both keys are needed:
+              # chttpd_auth.erl gates every other path on `RequireValidUser orelse
+              # RequireValidUserExceptUp`, and /_up on `RequireValidUser andalso
+              # not RequireValidUserExceptUp`.
+              require_valid_user_except_for_up = true;
+              # Obsidian is a browser origin. Safe alongside the two above:
+              # chttpd.erl answers the preflight *before* authenticating, so the
+              # credential-less OPTIONS a webview sends is not met with a 401.
+              enable_cors = true;
+            };
+
+            cors = {
+              credentials = true;
+              origins = "app://obsidian.md,capacitor://localhost,http://localhost";
+              # CouchDB's default is 600.
+              max_age = 3600;
+            };
+
+            # Otherwise /var/log/couchdb.log, which nothing rotates and which sits
+            # on a persistent subvolume.
+            log.writer = "journald";
+          };
+
+          # Four keys upstream's provisioning script sets are deliberately absent,
+          # each checked against couchdb 3.5.1's source: max_http_request_size is
+          # already the code default, chttpd_auth.require_valid_user is never read,
+          # httpd.WWW-Authenticate only changes the realm string, and
+          # cors.headers/cors.methods would *replace* chttpd_cors.erl's built-in
+          # lists rather than extend them — which already cover what pouchdb sends.
+          # ../../CLAUDE.md has the detail, including what a custom header costs.
+        };
+
+        # `mkRouter`, not `mkAutheliaRouter`, joining ./jellyfin.nix and
+        # ./radicale.nix: a phone's webview cannot complete a browser SSO round
+        # trip, and replication is a REST client besides.
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "couchdb";
+          inherit port;
+        };
+      };
+
+      # No uid pinned, unlike ./mealie.nix and ./radicale.nix: nixpkgs gives
+      # couchdb a static id (106).
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = "/var/lib/couchdb";
+          user = "couchdb";
+          group = "couchdb";
+          mode = "0750";
+        }
+      ];
+    };
+}

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -255,6 +255,15 @@
                 method = "PROPFIND";
                 status = 401;
               })
+              # Exempt from the middleware for the same reason again. `/_up` is
+              # the one path ./couchdb.nix leaves open, so this needs no
+              # credential; asserting the body keeps a 200 from anything other
+              # than CouchDB from counting.
+              (mkHttps {
+                name = "couchdb";
+                path = "/_up";
+                conditions = [ "[BODY].status == ok" ];
+              })
               (mkHttps { name = "immich"; })
               (mkHttps {
                 name = "garage";

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -39,6 +39,7 @@ autheliaOidcPaperlessClientSecretDigest: ENC[AES256_GCM,data:eOV9s8qezywKYGwO+iN
 autheliaOidcMealieClientSecret: ENC[AES256_GCM,data:CMYPB+0uEqElarvBlIfAKo4eQtQ+ubWZEn1gUFjJtdfsFNd9K8CoKpAsrp0eMqMk8kaZNsIiUoGMOsVtx1McTUNbLhqF/BVl,iv:q+NV3ngOSFyzDfrD1a2J3v8WY1eysvrygL2S4zsJ1V0=,tag:+80tIDD/uO+35wFTxs7MSA==,type:str]
 autheliaOidcMealieClientSecretDigest: ENC[AES256_GCM,data:/xcFwT7ehmkcxHS0ANyx6FwNWSmi8rfuN+vN6+r5CCmSgwRDRGZ5e0y/SFpMk7xOqRY8OhyQ7cT5iXJjOUGwgTd7J2ywy6vNaIuJdgygW9nlTEEBQfGYtgVOswol5JLqBTf63WjB6Byox7VdQbQDS1ut3XjW7bfY27lAFNg7DMEI1sA=,iv:KrRTLzkZl8GqxBD6O2tQR7eM2QZJTUpmCiUgB/oY5uE=,tag:bywR/D0b5K6VlctPJJJJ4g==,type:str]
 radicaleLdapPassword: ENC[AES256_GCM,data:NQYWqI9Urg2/PBx9qVryCa4eWOO5y7fcx9eTxOAntWM=,iv:jLf/vf805kI4d7mTQly0Cu4vrnLhifvgTVT8AT/BpMI=,tag:pBrH+68l8iW+kDYq65T6Gw==,type:str]
+couchdbAdminPassword: ENC[AES256_GCM,data:S51TlIN26Wf3vruvuiklppFz0QUTKB3QjdhrPtoGJ3IJNGFZQhEsYjjHqkgPihcSJg6CfqTa4yL+/pQitqLfiA==,iv:9gSmPrHHuSQ1NFvEosaR+7s15zVMXd1X2An5+v30bwQ=,tag:+RdBELba3oqHCPpzFGp3Aw==,type:str]
 sops:
     age:
         - enc: |
@@ -50,8 +51,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-06T16:29:25Z"
-    mac: ENC[AES256_GCM,data:EnenLD08wQbk4gmhBuJ+VjRkeFpmuMPVRKP9l3t+3m3BAliumUdtY42IQvkBSk3yZ3uEOp+mgeqnsqKLfUGFsn+dB8MbzQeJxsYo85UyiORcYebaIZ7Hi+UQwOWfP6SuKq3HMm2aRr3Z+dhv60iv6RVlMCKO2d/FXX3xCg0lQes=,iv:LkE0BTNuwuNnBsprunzfhouRcGmbdXk0qXv5WFUS9zM=,tag:6JSeQRrVImodiBf1e54eEQ==,type:str]
+    lastmodified: "2026-08-08T14:13:37Z"
+    mac: ENC[AES256_GCM,data:ol+yplVRAjkoueWcxA85GoA1Ekqjr2qezDEDhHOwfs2zGozmFVHlw18XdA5OnXl5k3EYa4ogxXLeL72lgMe0rgYyXCTUDf+50FlFCyx4PZkJeCw0nt7hjL4yFeR7V/0yvjHit2QVd3SPt0HF9yvhov9dRWSzofGAGD4KAsPqVVs=,iv:/yooanNdGvq3l+ukp1422vbW47i5bCHPlsDzixXem98=,tag:ILLGiceEm0J7mt/TK8iT/A==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
Adds a `couchdb` aspect serving the remote database the Obsidian
Self-hosted LiveSync plugin replicates a vault through. An ordinary
nixpkgs module, so the paperless/mealie/radicale shape rather than
grimmory's container.

`mkRouter` rather than `mkAutheliaRouter`, joining Jellyfin, Radicale
and the rest: a phone's webview cannot complete a browser SSO round
trip, and replication is a REST client besides. CouchDB speaks no LDAP
either, so unlike Radicale it cannot delegate to LLDAP and the
credential is local to it. sops holds a server admin used only to
bootstrap and maintain; what the plugin carries is a non-admin `_users`
account granted `member` through an `obsidian-livesync` role, created by
hand. That costs the plugin's "check and fix" and remote-rebuild flows,
both of which are server-admin only — and the first is unwanted here
anyway, since its fix button writes local.ini and would outrank the
generated config.

`require_valid_user` plus `require_valid_user_except_for_up`, so nothing
is anonymous except `/_up`, which is what the Gatus check asserts on.
Backups need no dump: the file format is append-only, so backup.nix
stages /var/lib/couchdb with the same rsync as everything else.

Four keys upstream's provisioning script sets are deliberately absent,
each checked against couchdb 3.5.1's source; CLAUDE.md records why, along
with the trap that cost the most to find — a `http://` remote URI is
308'd to https by Traefik, and a CORS preflight may not follow a
redirect, which the plugin reports as a CORS misconfiguration.
