### PR TITLE
feat(srv-01): shut down cleanly on a power cut as a NUT secondary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,54 @@ needs a login round trip before the query, which a Gatus websocket endpoint cann
 **a whole-house power or ISP outage** silences both machines — closing that needs an outbound
 heartbeat to something off-site.
 
+### Power on srv-01
+
+`ups` (`modules/server/ups.nix`) — a NUT **secondary**, nothing more. The UPS hangs off the
+TrueNAS's USB port and the NAS runs `upsd` as the primary, so `mode = "netclient"` and the module
+leaves `upsd`, `upsdrv` and `ups-killpower` all disabled: no driver here, no port opened, and the
+power is something this host learns about from the machine that can see it. The same split as
+`beszel` — the thing with the sensor is the thing that reports — and the same NAS address
+`gatus.nix` pings, deliberately an **address and not `nas.lan`**: this is the one client that has
+to keep working while the LAN is losing power, and the router answering DNS may not be on the UPS.
+
+**It shuts srv-01 down ten minutes into any outage, rather than riding the battery down.** The
+remaining runtime is worth more to the NAS, which is where the bytes are, and going first also gets
+this host off the NFS export before the server holding it disappears — a `hard` mount whose server
+is gone hangs the unmount. That is the whole of `upssched.conf`: `START-TIMER` on ONBATT,
+`CANCEL-TIMER` on ONLINE. The low-battery path underneath it needs no rule and is deliberately
+left alone — LOWBATT, or an FSD declared by the NAS, runs `SHUTDOWNCMD` at once whatever the timer
+is doing, which is what covers an outage starting on an already-drained battery.
+
+Three things fail misleadingly:
+
+- **`upssched`'s `CMDSCRIPT` runs unprivileged, so NUT's own idiom for this does not work.** upsmon
+  forks: the root parent exists only to run `SHUTDOWNCMD`, and the monitoring child drops to
+  `nutmon` before it ever execs `NOTIFYCMD`. So `upsmon -c fsd` from the command script dies with
+  EPERM — it signals a root-owned pid. The script drops a marker in `/run/upssched` instead, and a
+  `systemd.paths` unit whose `Unit` is `poweroff.target` does the rest — cheaper than a polkit
+  rule, much cheaper than setting `upsmon.user = "root"` (the thing that fork exists to avoid), and
+  with no service in between to be stopped by the transaction it just asked for. That directory is
+  its own and not `/run/nut`, which the module's `ExecStartPre` creates root-owned.
+- **`type` must be stated.** The nixpkgs default is `"master"`, and the NAS grants this account
+  `upsmon secondary`, so leaving it logs "Primary privileges unavailable" on every poll.
+- **`passwordFile` must be stated too.** It defaults to `power.ups.users.<user>.passwordFile`, and
+  that attrset exists to generate `upsd.users` — the primary's file, which this host does not have.
+  Left out, the host fails to evaluate rather than failing at runtime, which is the good half of
+  the trap.
+
+`PIPEFN` also has to precede the `AT` lines in `upssched.conf`, or upssched refuses to parse it.
+
+Two things are documented rather than fixed. **srv-01 does not come back by itself**: an early
+shutdown happens while the UPS still has charge, so its outlet is never de-energized — it needs a
+manual power-on, or a BIOS "restore on AC power loss" plus an outage long enough that the UPS
+actually drops the outlet. And **a secondary is blind if the primary dies**: if the NAS goes away
+rather than the mains, upsmon logs `COMMBAD`/`NOCOMM` and keeps running. Power events go to the
+journal and nowhere else; there is no Pushover route and no Gatus endpoint here.
+
+One setting on the NAS is load-bearing from here: its **Shutdown Mode must stay "UPS reaches low
+battery"**. On "UPS goes on battery" it declares FSD immediately, which takes srv-01 down with it
+and makes the ten-minute timer dead config. Bring-up is in README.md, "Bringing up the UPS client".
+
 ### Media on srv-01
 
 Seven aspects, split along the lines that actually differ:
@@ -737,7 +785,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", and CouchDB in "Obsidian sync on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; it is a NUT secondary of the UPS on the NAS — see "Power on srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", and CouchDB in "Obsidian sync on srv-01"
 
 ### Module Organization
 
@@ -745,7 +793,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -921,7 +969,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,64 @@ Two things the non-admin account cannot do, both by design:
 
 Routine compaction needs neither: CouchDB's smoosh daemon compacts on its own by default.
 
+### Bringing up the UPS client
+
+The UPS is on the TrueNAS's USB port and the NAS runs NUT's `upsd` as the primary;
+`modules/server/ups.nix` makes srv-01 a **secondary** that shuts itself down ten minutes into an
+outage, handing the rest of the battery to the NAS. The account it authenticates with lives in the
+NAS's `upsd.users` and cannot come from this repo, so the first run is a short bootstrap:
+
+1. **TrueNAS** — System Settings → Services → **UPS**. Confirm the **Identifier** (`ups` is the
+   default, and what `modules/server/ups.nix` expects) and that the local side works: `upsc ups`
+   on the NAS should print the UPS's variables.
+2. Tick **Remote Monitor**. That toggle and nothing else is what turns `LISTEN 127.0.0.1` into
+   `LISTEN 0.0.0.0 3493` — the docs describe it as also setting a well-known user and password,
+   which is stale: those are just the default values of the *Monitor User*/*Monitor Password*
+   fields. Leave those as the NAS's own; srv-01 does not reuse them.
+3. **Extra Users** — this field is pasted into `upsd.users` verbatim, so put a dedicated account
+   for srv-01 in it:
+
+   ```
+   [srv-01]
+       password = <a generated alphanumeric password>
+       upsmon secondary
+   ```
+
+   No leading tab on the `[srv-01]` line, and leave a trailing newline: NAS-121082 is an open bug
+   where stray whitespace in this field makes the account silently fail to authenticate.
+   `secondary` and not `master` — this host runs nothing that another waits on.
+4. **Shutdown Mode** must stay **"UPS reaches low battery"**. On "UPS goes on battery" the NAS
+   declares FSD the moment the power fails, which takes srv-01 down with it and makes the
+   ten-minute timer dead config. Restart the UPS service.
+5. `sops secrets/srv-01.yaml` and add `upsMonitorPassword` — the same password, which
+   `modules/server/ups.nix` hands to upsmon through `LoadCredential`. Avoid a literal `"`: the
+   generated `MONITOR` line quotes it.
+6. `just deploy srv-01`, then check from srv-01:
+
+   ```bash
+   upsc ups@10.0.0.55 ups.status     # OL
+   journalctl -u upsmon -n 50        # no "Login failed", no "Primary privileges unavailable"
+   systemctl status ups-early-shutdown.path
+   ```
+
+To exercise the timer without pulling the mains lead, inject the notification upsmon would send —
+`upssched` is a daemon holding a timer, so this is the only way to test it end to end:
+
+```bash
+sudo -u nutmon env NUT_CONFPATH=/etc/nut UPSNAME=ups@10.0.0.55 NOTIFYTYPE=ONBATT upssched
+sudo -u nutmon env NUT_CONFPATH=/etc/nut UPSNAME=ups@10.0.0.55 NOTIFYTYPE=ONLINE upssched
+```
+
+The first starts the **real** 600-second timer; run the second, or the host powers off in ten
+minutes. To confirm the privileged half on its own, `sudo -u nutmon touch
+/run/upssched/early-shutdown` — srv-01 should power off immediately.
+
+Two things to expect from a real outage. srv-01 **does not come back by itself**: it powers off
+while the UPS still has charge, so its outlet is never de-energized, and it needs a manual
+power-on unless the BIOS is set to restore on AC power loss *and* the outage outlasts the battery.
+And if the **NAS** is what dies rather than the mains, srv-01 has no other source of UPS state — it
+logs `COMMBAD`/`NOCOMM` and keeps running.
+
 ### Managing Secrets
 
 Secrets are managed with SOPS (uses age encryption):

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -16,6 +16,7 @@
         homeAssistant
         gatus
         beszel
+        ups
         mediaLibrary
         jellyfin
         servarr

--- a/modules/server/ups.nix
+++ b/modules/server/ups.nix
@@ -1,0 +1,121 @@
+{ ... }:
+{
+  # A NUT secondary, and nothing else. The UPS is on the TrueNAS's USB port and
+  # the NAS runs `upsd` as the primary, so this host holds no driver and opens no
+  # port: it learns about the power from the machine that can see it. Same split
+  # as ./beszel.nix, for the same reason.
+  #
+  # What it does with that: shuts srv-01 down **ten minutes into any outage**
+  # rather than riding the battery down. The rest of the runtime is worth more to
+  # the NAS, which is where the bytes are, and going first also gets this host off
+  # the NFS export in ./media-library.nix before the server holding it disappears
+  # — a `hard` mount whose server is gone hangs the unmount.
+  #
+  # Two things it cannot do, both in ../../CLAUDE.md: bring itself back up, since
+  # the outlet is never de-energized; and notice an outage at all when the NAS is
+  # what died rather than the mains.
+  nixos.modules.ups =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      onBattSeconds = 600;
+
+      # upssched's socket and lock. Not /run/nut, which the module's ExecStartPre
+      # creates root-owned.
+      runtimeDir = "/run/upssched";
+      trigger = "${runtimeDir}/early-shutdown";
+
+      # upsmon forks: the root parent exists only to run SHUTDOWNCMD, and the
+      # monitoring child drops to `nutmon` before it execs NOTIFYCMD. So upssched
+      # and this script are unprivileged, and NUT's own idiom — `upsmon -c fsd` —
+      # fails with EPERM against a root-owned pid. Dropping a marker for a path
+      # unit to watch is cheaper than a polkit rule, and much cheaper than running
+      # the whole of upsmon as root.
+      cmdScript = pkgs.writeShellScript "upssched-cmd" ''
+        case "$1" in
+          earlyshutdown) ${lib.getExe' pkgs.coreutils "touch"} ${trigger} ;;
+        esac
+      '';
+    in
+    {
+      sops.secrets.upsMonitorPassword = { };
+
+      power.ups = {
+        enable = true;
+        mode = "netclient";
+
+        upsmon = {
+          monitor.nas = {
+            # The address and not `nas.lan` as ../_hosts/_lib/nfs.nix uses: this
+            # is the one client that has to keep working while the LAN is losing
+            # power, and the router answering DNS may not be on the UPS. `ups` is
+            # the identifier TrueNAS defaults to.
+            system = "ups@10.0.0.55";
+            user = "srv-01";
+
+            # Stated rather than defaulted: the option falls back to
+            # `power.ups.users.<user>.passwordFile`, and that attrset generates
+            # upsd.users — the primary's file, which this host does not have.
+            passwordFile = config.sops.secrets.upsMonitorPassword.path;
+
+            # Not the module's "master" default: the NAS grants this account
+            # `upsmon secondary`, so claiming primary logs "Primary privileges
+            # unavailable" on every poll and buys nothing.
+            type = "secondary";
+          };
+
+          # Only the two events the timer keys off gain EXEC; the rest keep
+          # upsmon's SYSLOG default, which is the whole of the alerting here.
+          # NOTIFYCMD is already upssched.
+          settings.NOTIFYFLAG = [
+            [
+              "ONBATT"
+              "SYSLOG+EXEC"
+            ]
+            [
+              "ONLINE"
+              "SYSLOG+EXEC"
+            ]
+          ];
+        };
+
+        # The early shutdown only. The low-battery path underneath it needs no
+        # rule: LOWBATT, or an FSD declared by the NAS, runs SHUTDOWNCMD at once
+        # whatever the timer is doing. PIPEFN has to precede the ATs, or upssched
+        # refuses to parse this at all.
+        schedulerRules = "${pkgs.writeText "upssched.conf" ''
+          CMDSCRIPT ${cmdScript}
+          PIPEFN ${runtimeDir}/upssched.pipe
+          LOCKFN ${runtimeDir}/upssched.lock
+
+          AT ONBATT * START-TIMER earlyshutdown ${toString onBattSeconds}
+          AT ONLINE * CANCEL-TIMER earlyshutdown
+        ''}";
+      };
+
+      systemd = {
+        # upssched creates its socket and lock here, as nutmon.
+        tmpfiles.settings.ups.${runtimeDir}.d = {
+          user = "nutmon";
+          group = "nutmon";
+          mode = "0700";
+        };
+
+        # The privileged half of cmdScript above. Starting the target is what
+        # `systemctl poweroff` does anyway, so no service sits in between — which
+        # also avoids a oneshot unit asking for a transaction that stops itself.
+        paths.ups-early-shutdown = {
+          description = "Power off ${toString (onBattSeconds / 60)} minutes into an outage";
+          wantedBy = [ "multi-user.target" ];
+          pathConfig = {
+            PathExists = trigger;
+            Unit = "poweroff.target";
+          };
+        };
+      };
+    };
+}

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -40,6 +40,7 @@ autheliaOidcMealieClientSecret: ENC[AES256_GCM,data:CMYPB+0uEqElarvBlIfAKo4eQtQ+
 autheliaOidcMealieClientSecretDigest: ENC[AES256_GCM,data:/xcFwT7ehmkcxHS0ANyx6FwNWSmi8rfuN+vN6+r5CCmSgwRDRGZ5e0y/SFpMk7xOqRY8OhyQ7cT5iXJjOUGwgTd7J2ywy6vNaIuJdgygW9nlTEEBQfGYtgVOswol5JLqBTf63WjB6Byox7VdQbQDS1ut3XjW7bfY27lAFNg7DMEI1sA=,iv:KrRTLzkZl8GqxBD6O2tQR7eM2QZJTUpmCiUgB/oY5uE=,tag:bywR/D0b5K6VlctPJJJJ4g==,type:str]
 radicaleLdapPassword: ENC[AES256_GCM,data:NQYWqI9Urg2/PBx9qVryCa4eWOO5y7fcx9eTxOAntWM=,iv:jLf/vf805kI4d7mTQly0Cu4vrnLhifvgTVT8AT/BpMI=,tag:pBrH+68l8iW+kDYq65T6Gw==,type:str]
 couchdbAdminPassword: ENC[AES256_GCM,data:S51TlIN26Wf3vruvuiklppFz0QUTKB3QjdhrPtoGJ3IJNGFZQhEsYjjHqkgPihcSJg6CfqTa4yL+/pQitqLfiA==,iv:9gSmPrHHuSQ1NFvEosaR+7s15zVMXd1X2An5+v30bwQ=,tag:+RdBELba3oqHCPpzFGp3Aw==,type:str]
+upsMonitorPassword: ENC[AES256_GCM,data:A0wAwvAr0JmI3zIUL21awZQaaQ8mNcXan63g4+vVvwc=,iv:ixyYOS39plBeMkuWYDgMxCjyXEBc1e+jKH4b58mkA8Q=,tag:1znEZOL7wuS20UDsp4Ev3w==,type:str]
 sops:
     age:
         - enc: |
@@ -51,8 +52,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-08T14:13:37Z"
-    mac: ENC[AES256_GCM,data:ol+yplVRAjkoueWcxA85GoA1Ekqjr2qezDEDhHOwfs2zGozmFVHlw18XdA5OnXl5k3EYa4ogxXLeL72lgMe0rgYyXCTUDf+50FlFCyx4PZkJeCw0nt7hjL4yFeR7V/0yvjHit2QVd3SPt0HF9yvhov9dRWSzofGAGD4KAsPqVVs=,iv:/yooanNdGvq3l+ukp1422vbW47i5bCHPlsDzixXem98=,tag:ILLGiceEm0J7mt/TK8iT/A==,type:str]
+    lastmodified: "2026-08-09T13:56:01Z"
+    mac: ENC[AES256_GCM,data:Q7cqqSq3vMd1uFbzdplHRhKgD4rSK0OMm0ra8ogA9Roe/Y+GKSFVAr9+jzI1fyjKfX3Lmk+96fXaveDAdj/8FV/zlvc7j1LwBuHYWkBaetQMnM1IjhKORDFTb8Z5qslI2XmSgrdR4NoMuimtY2rzo0yROnL+skCTg5442qRroB4=,iv:TlydWqhgfXQ8udPfEaujfRGZH0O9r9nRwUCx7wcDHuE=,tag:YOWOp1cDAKPJjFlW95iLhg==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
The UPS is on the TrueNAS's USB port and the NAS already runs upsd as the
primary, so a mains outage took this host down uncleanly, mid-write, with
a MariaDB and a PostgreSQL cluster and a HAOS guest running. The new
`ups` aspect makes it a NUT secondary: mode = netclient, so no driver, no
upsd and nothing listening — it learns about the power from the machine
that can see it, the same split as beszel.nix and for the same reason.

It shuts down ten minutes into any outage rather than riding the battery
down. The rest of the runtime is worth more to the NAS, which is where
the bytes are, and going first also gets this host off media-library's
NFS export before the server holding it disappears — a hard mount whose
server is gone hangs the unmount. That is the whole of upssched.conf, a
START-TIMER on ONBATT cancelled on ONLINE; the low-battery path
underneath needs no rule, since LOWBATT or an FSD declared by the NAS
runs SHUTDOWNCMD at once whatever the timer is doing.

upssched's CMDSCRIPT runs unprivileged, and that shapes the rest. upsmon
forks: the root parent exists only to run SHUTDOWNCMD, and the monitoring
child drops to nutmon before it execs NOTIFYCMD, so NUT's own idiom —
upsmon -c fsd — dies with EPERM against a root-owned pid. The script
drops a marker in /run/upssched instead and a systemd.paths unit aimed at
poweroff.target does the rest: cheaper than a polkit rule, much cheaper
than running the whole of upsmon as root, and with no service in between
to be stopped by the transaction it just asked for. That directory is its
own and not /run/nut, which the module's ExecStartPre creates root-owned.

Two option defaults have to be overridden or they fail misleadingly.
`type` defaults to "master" while the NAS grants this account
`upsmon secondary`, so leaving it logs "Primary privileges unavailable"
on every poll. `passwordFile` defaults to
power.ups.users.<user>.passwordFile — that attrset generates upsd.users,
the primary's file, which a netclient does not have — so stating it is
what keeps this an eval failure rather than a runtime one.

Power events go to the journal and nowhere else: no Pushover route and no
Gatus endpoint. Nothing to preserve and nothing to stage in backup.nix
either, since a netclient writes no state, which is also why nutmon's uid
is left unpinned where most siblings here pin theirs.

Two limits are documented rather than fixed. srv-01 does not come back by
itself — an early shutdown leaves the outlet energized, so it needs a
manual power-on unless the BIOS restores on AC loss and the outage
outlasts the battery. And a secondary is blind if the primary dies: when
the NAS goes away rather than the mains, upsmon logs COMMBAD/NOCOMM and
keeps running.

The NAS side cannot come from this repo, so README.md carries the
bootstrap. One setting there is load-bearing: its Shutdown Mode must stay
"UPS reaches low battery", because on "UPS goes on battery" it declares
FSD the moment power fails, which takes srv-01 down with it and makes the
ten-minute timer dead config.
