### PR TITLE
feat(srv-01): add Miniflux as the news reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,10 +154,13 @@ snapshot task, not anything here, and `/var/lib/traefik` is deliberately out of 
 `acme.json` holds the wildcard cert's private key, which Cloudflare DNS re-issues for free.
 Restores are in README.md.
 
-Every database staged is sqlite through the online-backup API, **except Grimmory**, whose library
-metadata, users and OIDC client are in MariaDB and go through `mariadb-dump --single-transaction`.
-That dump is also the only backup of configuration this repo cannot rebuild — see "Books on
-srv-01".
+Every database staged is sqlite through the online-backup API, **except two**. Grimmory's library
+metadata, users and OIDC client are in MariaDB and go through `mariadb-dump --single-transaction`;
+that dump is also the only backup of configuration this repo cannot rebuild — see "Books on
+srv-01". Miniflux is in PostgreSQL and goes through `pg_dump`, one database rather than
+`pg_dumpall`: Paperless shares the cluster but is staged by its own exporter, so dumping
+everything would carry a second copy of it. Both run under `runuser`, because peer authentication
+on either socket authenticates the *OS* user and root is the superuser of neither.
 
 ### Monitoring srv-01
 
@@ -451,8 +454,9 @@ the multifunction printer already attached to this host into an intake pipeline.
     plus three celery processes — write concurrently, which is where sqlite starts returning
     `database is locked`. It is the second engine on this host after Grimmory's MariaDB; that costs
     nothing in `backup.nix`, because the exporter below makes the engine invisible there.
-    `/var/lib/postgresql` is preserved as the **parent**, not `dataDir` — the latter carries the
-    major version, so pinning it would silently land the next cluster on the tmpfs root.
+    The cluster itself is **not** preserved here: it is shared with Miniflux and owned by the
+    `postgresql` aspect (see "News on srv-01"), whose `requirePostgresql` this file calls in its
+    `assertions` so the dependency cannot go silent.
   - **Backed up by its own tooling.** `services.paperless.exporter` runs `document_exporter` at
     00:30 into `/var/lib/paperless/export`, and `backup.nix` rsyncs *that* — not the media
     directory and not a database dump. The export is self-contained (originals, archive PDFs, a
@@ -546,11 +550,14 @@ to pin, no Renovate `customManagers` entry, the weekly lockfile PR covers it. Fo
 easy to get wrong:
 
 - **SQLite, not the PostgreSQL the module can bring up.** `database.createLocally = true` would
-  reuse the cluster `paperless` starts, but `/var/lib/postgresql` is preserved *in
-  `paperless.nix`*, so `mealie` would silently depend on that aspect being imported — the opposite
-  of the loud eval failure `mediaLibrary` and `mkHeartbeat` are built for. As one file at
-  `/var/lib/mealie/mealie.db` it instead falls into `backup.nix`'s existing online-backup loop
-  beside every other sqlite service here.
+  reuse the shared cluster, and at the time that cluster was preserved *inside* `paperless.nix`,
+  so `mealie` would have depended on that aspect being imported without saying so — the opposite
+  of the loud eval failure `mediaLibrary` and `mkHeartbeat` are built for. That specific hazard is
+  gone (the `postgresql` aspect and its `requirePostgresql` now exist, because Miniflux had no
+  sqlite option to fall back on), but the choice stands on its own merits: as one file at
+  `/var/lib/mealie/mealie.db` it falls into `backup.nix`'s existing online-backup loop beside
+  every other sqlite service here, where PostgreSQL would need a second `pg_dump` for a database
+  a single process writes.
 - **`settings` is rendered into `Environment=`,** which reaches the store *and* the journal, so the
   OIDC client secret goes through the module's `credentialsFile` from a sops template — the same
   split `shelfmark.nix` makes for its API keys. Note also that the module passes every `settings`
@@ -705,6 +712,61 @@ one ordering rule they give — secondary indexes before the databases — falls
 walk, since `.shards/` precedes `shards/`. The uid is *not* pinned, unlike every sibling here:
 nixpkgs gives couchdb a static id (106).
 
+### News on srv-01
+
+`miniflux` (`modules/server/miniflux.nix`) — the feed reader. RSS and Atom only, deliberately:
+Reddit publishes a feed per subreddit, per user and per multireddit (`…/.rss`), as do YouTube
+channels and most news sites, so no bridge (RSS-Bridge, RSSHub) is deployed to manufacture feeds
+for sites that publish none — that would be a new aspect, not a setting here. The
+`paperless`/`mealie`/`radicale`/`couchdb` shape (an ordinary nixpkgs module), and `mkRouter`
+rather than `mkAutheliaRouter`, joining Jellyfin, Jellyseerr, Grimmory, Paperless, Mealie,
+Radicale and CouchDB: the phone clients speak Miniflux's own API — or the Fever and Google Reader
+ones it also serves, enabled per user under Settings → Integrations — which no browser SSO round
+trip can serve.
+
+**It is the only service here with no state of its own.** Feeds, entries, users, API keys and the
+OIDC link are all rows; Miniflux has no sqlite mode and no data directory. So it runs under
+`DynamicUser` with nothing preserved and no uid pinned, and its backup is a `pg_dump`.
+
+That is what forced the `postgresql` aspect (`modules/server/postgresql.nix`). The cluster was
+brought up and preserved as a side effect of `paperless`, and a second consumer depending on that
+silently is what `mealie.nix` stays on sqlite to avoid. So `/var/lib/postgresql` — the parent, not
+`dataDir`, which carries the major version — moved into an aspect of its own, publishing
+`requirePostgresql` in the `mkHeartbeat` idiom. `paperless` and `miniflux` both call it in their
+`assertions`, so a host importing either without the cluster aspect fails to evaluate rather than
+putting the database on the tmpfs root.
+
+Four things fail misleadingly:
+
+- **`OAUTH2_OIDC_DISCOVERY_ENDPOINT` is the issuer, not the discovery document.** go-oidc appends
+  `/.well-known/openid-configuration` itself and then compares the `issuer` it gets back against
+  the string byte for byte — so unlike Mealie's `OIDC_CONFIGURATION_URL` this takes neither that
+  suffix nor a trailing slash, and either one fails at *startup* (`Failed to initialize OIDC
+  provider`) rather than at the first login.
+- **The secrets cannot go in `config`.** The module renders that attrset into the unit's
+  `Environment=`, which reaches the store and the journal — `shelfmark.nix`'s trap. Its
+  `adminCredentialsFile` is the *only* `EnvironmentFile=` hook it offers, so the admin password
+  and the OIDC client secret share one sops template. That file is left root-owned, unlike every
+  sibling here: `DynamicUser` leaves no account to chown to, and PID 1 reads `EnvironmentFile=`
+  before dropping privileges.
+- **`config`'s freeform type is `str`/`int`.** Only `CREATE_ADMIN`, `RUN_MIGRATIONS` and
+  `WATCHDOG` coerce a bool, so everything else is `0`/`1` — `OAUTH2_USER_CREATION = false` would
+  be `toString false`, the empty string, the edge `mealie.nix` documents.
+- **`LISTEN_ADDR` must be stated.** Its default is `localhost:8080`, which is Gatus's port.
+
+The Authelia client differs from all four others (see "Authentication on srv-01"): PKCE **S256 is
+required**, because Miniflux hardcodes a challenge on every authorization request; there is no
+`userinfo_signed_response_alg`, because it verifies the ID token *and* calls userinfo and requires
+the two subjects to match, so Immich's RS256 breaks it as it does Paperless; there is no
+`claims_policy`, because the username claims come from userinfo, not the ID token; and there is no
+`token_endpoint_auth_method`, because `golang.org/x/oauth2` auto-detects and tries basic —
+Authelia's default — first.
+
+`OAUTH2_USER_CREATION` stays off and the local login stays enabled, both for Paperless's reasons:
+the Authelia identity is *linked* onto the existing account from the settings page rather than
+self-provisioned, and the password login is the way in when Authelia is the thing that is down.
+Bring-up is in README.md, "Bringing up Miniflux".
+
 ### Formatting and Linting
 
 ```bash
@@ -785,7 +847,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; it is a NUT secondary of the UPS on the NAS — see "Power on srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", and CouchDB in "Obsidian sync on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, Miniflux, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; it is a NUT secondary of the UPS on the NAS — see "Power on srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", CouchDB in "Obsidian sync on srv-01", and Miniflux plus the shared PostgreSQL cluster in "News on srv-01"
 
 ### Module Organization
 
@@ -793,7 +855,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `postgresql`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`, `miniflux`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -807,12 +869,14 @@ each feature adds to it beside its own config:
   group outside it. Tiles are sorted by name within a group, since merge order follows module
   evaluation rather than intent.
 - `mkRouter` / `mkAutheliaRouter` (`modules/server/traefik-router.nix`), `mkHeartbeat`
-  (`modules/server/gatus.nix`) and `mediaLibrary` (`modules/server/media-library.nix`) are the
-  same idea via `_module.args`: a builder or a constant defined once, read by each feature.
+  (`modules/server/gatus.nix`), `mediaLibrary` (`modules/server/media-library.nix`) and
+  `requirePostgresql` (`modules/server/postgresql.nix`) are the same idea via `_module.args`: a
+  builder or a constant defined once, read by each feature.
 
-Both create a real dependency — an aspect using `homepageTiles`, `mkHeartbeat` or `mediaLibrary`
-will not evaluate on a host that omits `homepage`, `gatus` or `mediaLibrary`. That is deliberate: a loud eval failure beats a tile
-that renders nowhere or a job that reports to nothing.
+Both create a real dependency — an aspect using `homepageTiles`, `mkHeartbeat`, `mediaLibrary` or
+`requirePostgresql` will not evaluate on a host that omits `homepage`, `gatus`, `mediaLibrary` or
+`postgresql`. That is deliberate: a loud eval failure beats a tile
+that renders nowhere, a job that reports to nothing, or a database on a tmpfs root.
 
 Most features are flat `modules/<feature>.nix` files; directories appear only for a cohesive multi-file capability (`desktop/`) or a peer-set (`machines/`, `server/`, `shells/`). Per-user config goes through `homeManager.modules.base` (every host) / `homeManager.modules.gui` (desktop) inside the owning feature file — never `home-manager.users.*` directly (except the wiring in `users.nix`).
 
@@ -969,7 +1033,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `postgresql`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`, `miniflux`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,25 @@ carries the *hashed* admin password as it was, and outranks the sops one. If `co
 has changed since the backup, `rm /var/lib/couchdb/local.ini` before starting and CouchDB will
 re-hash from sops.
 
+Miniflux is the mirror image of Radicale: nothing but a database. Feeds, entries, users, API keys
+and the OIDC link are all rows in the PostgreSQL cluster it shares with Paperless, and there is no
+directory to rsync:
+
+```bash
+systemctl stop miniflux
+
+runuser -u postgres -- psql miniflux < <pulled>/postgresql/miniflux.sql
+
+systemctl start miniflux
+```
+
+The dump carries no `CREATE DATABASE` — the target is the empty database `services.miniflux`
+declares on a rebuilt host — and `runuser` is needed for MariaDB's reason above: peer
+authentication on the socket authenticates the OS user, and PostgreSQL's superuser is `postgres`.
+The local admin comes back from sops on first start either way, and the Authelia link is in the
+dump. Paperless shares that cluster but is not restored this way: its own exporter above is what
+carries it, which is why the dump names one database rather than being a `pg_dumpall`.
+
 Jellyfin's artwork is deliberately not in the backup — it re-fetches it — so expect the libraries
 to look bare until the first metadata scan finishes. Neither SABnzbd nor Recyclarr is in the
 backup either: the first holds a re-downloadable queue, the second a clone of the TRaSH guides and
@@ -540,6 +559,36 @@ Two things the non-admin account cannot do, both by design:
   Paste the admin credential into the plugin for that one operation, then put the account back.
 
 Routine compaction needs neither: CouchDB's smoosh daemon compacts on its own by default.
+
+### Bringing up Miniflux
+
+Miniflux is the feed reader. It authenticates against Authelia over OIDC, but — unlike Mealie —
+the identity is **linked onto an existing account** rather than creating one, so the first run
+needs the local admin the module seeds from sops:
+
+1. `sops secrets/srv-01.yaml` and add three values:
+   - `minifluxAdminPassword` — the local admin's password, at least six characters. The account
+     is `tguimbert`, named in `modules/server/miniflux.nix`.
+   - `autheliaOidcMinifluxClientSecret` and `autheliaOidcMinifluxClientSecretDigest` — a pair from
+     `authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72`, exactly
+     as for Mealie: the plaintext goes into Miniflux's environment file, the digest into
+     `modules/server/authelia.nix`.
+2. `just deploy srv-01`, then `ssh srv-01.local journalctl -u miniflux | grep -i oidc`. A wrong
+   `OAUTH2_OIDC_DISCOVERY_ENDPOINT` fails **here, at startup** (`Failed to initialize OIDC
+   provider`) and not at the first login.
+3. Open `https://miniflux.home.guimbert.fr`, log in with `tguimbert` and the password from step 1,
+   and use **Settings → Link my Authelia account** (the link at the top of the page). Log out and
+   back in through *Sign in with Authelia* to confirm it took. Account creation over OIDC is off,
+   so that link is the only other way in besides the password — which stays enabled on purpose:
+   it is what still works when Authelia is the thing that is down.
+4. For phone and desktop reader apps, **Settings → Integrations**: Miniflux serves its own API
+   and also the Fever and Google Reader ones, each with a credential generated there. The route
+   carries no Authelia middleware precisely so those clients work.
+
+Adding feeds needs no bridge: Reddit publishes `https://www.reddit.com/r/<sub>/.rss`, and the same
+for a user or a multireddit, as do YouTube channels. A **403** from Reddit is it refusing the
+fetcher's user agent, not a misconfiguration — set a per-feed **User Agent** in the feed's
+settings.
 
 ### Bringing up the UPS client
 

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -17,6 +17,7 @@
         gatus
         beszel
         ups
+        postgresql
         mediaLibrary
         jellyfin
         servarr
@@ -30,6 +31,7 @@
         mealie
         radicale
         couchdb
+        miniflux
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/server/authelia.nix
+++ b/modules/server/authelia.nix
@@ -45,6 +45,7 @@
           autheliaOidcGrimmoryClientSecretDigest = sopsConfig;
           autheliaOidcPaperlessClientSecretDigest = sopsConfig;
           autheliaOidcMealieClientSecretDigest = sopsConfig;
+          autheliaOidcMinifluxClientSecretDigest = sopsConfig;
         };
       };
       services = {
@@ -281,6 +282,40 @@
                   # Grimmory's fix is unnecessary. No
                   # `userinfo_signed_response_alg`: Immich's RS256 would hand that
                   # fallback a JWT where it expects JSON, as it would Paperless.
+                }
+                {
+                  client_id = "miniflux";
+                  client_name = "Miniflux";
+                  client_secret = "{{ secret \"${config.sops.secrets.autheliaOidcMinifluxClientSecretDigest.path}\" }}";
+                  public = false;
+                  authorization_policy = "two_factor";
+                  consent_mode = "pre-configured";
+                  pre_configured_consent_duration = "1 year";
+                  # Required rather than permitted, as for Grimmory and Mealie:
+                  # Miniflux hardcodes an S256 challenge on every authorization
+                  # request.
+                  require_pkce = true;
+                  pkce_challenge_method = "S256";
+                  response_types = [ "code" ];
+                  grant_types = [ "authorization_code" ];
+                  id_token_signed_response_alg = "RS256";
+                  # Built from ./miniflux.nix's BASE_URL plus the route
+                  # /oauth2/{provider}/callback, so the two have to match.
+                  redirect_uris = [ "https://miniflux.${constants.domain}/oauth2/oidc/callback" ];
+                  # Exactly what Miniflux asks for; it maps no groups.
+                  scopes = [
+                    "openid"
+                    "profile"
+                    "email"
+                  ];
+                  # Three omissions, all deliberate. No
+                  # `userinfo_signed_response_alg`: Miniflux verifies the ID
+                  # token *and* calls userinfo, requiring the two subjects to
+                  # match, so Immich's RS256 would break it as it does Paperless.
+                  # No `claims_policy`: the username claims come from userinfo,
+                  # not the ID token Grimmory needs one for. And no
+                  # `token_endpoint_auth_method`: golang.org/x/oauth2
+                  # auto-detects, trying basic — Authelia's default — first.
                 }
               ];
               claims_policies.grimmory.id_token = [

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -86,6 +86,10 @@
       # here that is not sqlite, and the only configuration in the backup that a
       # rebuild cannot reproduce — ../../CLAUDE.md, "Books on srv-01".
       grimmoryDb = "grimmory";
+
+      # Miniflux keeps everything in PostgreSQL and nothing on disk, so this dump
+      # is the whole of it: feeds, entries, API keys and the OIDC link.
+      minifluxDb = "miniflux";
     in
     {
       users = {
@@ -131,7 +135,10 @@
             # For `mariadb-dump` below — the client half of the same package
             # ./grimmory.nix runs the server from.
             config.services.mysql.package
-            # `runuser`, for the same dump.
+            # For `pg_dump`, likewise the client half of ./postgresql.nix's
+            # cluster.
+            config.services.postgresql.package
+            # `runuser`, for both of those dumps.
             pkgs.util-linux
           ];
           # Reports the outcome to ./gatus.nix, which alerts both when this fails
@@ -200,6 +207,19 @@
               mariadb-dump --single-transaction --databases ${grimmoryDb} \
               > ${stagingDir}/mysql/${grimmoryDb}.sql
             chown nas-backup:nas-backup ${stagingDir}/mysql/${grimmoryDb}.sql
+
+            # `runuser` for the same reason, mirrored: peer authentication on the
+            # socket makes `postgres` the superuser, not root. pg_dump takes its
+            # own snapshot, so ./miniflux.nix keeps serving throughout.
+            #
+            # This database rather than pg_dumpall: ./paperless.nix shares the
+            # cluster but is staged by its own exporter above, so dumping
+            # everything would carry a second copy of it.
+            install -d -o nas-backup -g nas-backup -m 0750 ${stagingDir}/postgresql
+            runuser -u ${config.services.postgresql.superUser} -- \
+              pg_dump ${minifluxDb} \
+              > ${stagingDir}/postgresql/${minifluxDb}.sql
+            chown nas-backup:nas-backup ${stagingDir}/postgresql/${minifluxDb}.sql
           '';
         };
 

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -255,6 +255,15 @@
                 method = "PROPFIND";
                 status = 401;
               })
+              # Exempt for the same reason again — its phone clients speak
+              # Miniflux's own API. `/healthcheck` is the one of its three
+              # unauthenticated health paths that touches PostgreSQL; `/healthz`
+              # and `/liveness` would stay green with the database gone.
+              (mkHttps {
+                name = "miniflux";
+                path = "/healthcheck";
+                conditions = [ "[BODY] == OK" ];
+              })
               # Exempt from the middleware for the same reason again. `/_up` is
               # the one path ./couchdb.nix leaves open, so this needs no
               # credential; asserting the body keeps a 200 from anything other

--- a/modules/server/miniflux.nix
+++ b/modules/server/miniflux.nix
@@ -1,0 +1,108 @@
+{ ... }:
+{
+  # The news reader: RSS and Atom, which is what Reddit, YouTube and most news
+  # sites publish natively, so nothing here manufactures feeds. An ordinary
+  # nixpkgs module, the ./paperless.nix shape rather than the ./grimmory.nix one.
+  # ../../CLAUDE.md, "News on srv-01".
+  nixos.modules.miniflux =
+    {
+      config,
+      constants,
+      mkRouter,
+      requirePostgresql,
+      ...
+    }:
+    let
+      # Stated rather than defaulted: LISTEN_ADDR's own default is
+      # localhost:8080, which is ./gatus.nix's port.
+      port = 8087;
+      baseUrl = "https://miniflux.${constants.domain}";
+    in
+    {
+      # Miniflux has no sqlite mode and nothing on disk — feeds, entries, users,
+      # API keys and the OIDC link are all rows — so its whole state is the
+      # cluster ./postgresql.nix preserves and ./backup.nix dumps. Hence also no
+      # preservation entry and no pinned uid here.
+      assertions = [ (requirePostgresql "miniflux") ];
+
+      homepageTiles.Services = [
+        {
+          Miniflux = {
+            icon = "miniflux.png";
+            href = baseUrl;
+            siteMonitor = baseUrl;
+            description = "News and RSS reader";
+          };
+        }
+      ];
+
+      sops = {
+        secrets = {
+          # Six characters minimum, or the module's CREATE_ADMIN path refuses to
+          # create the account.
+          minifluxAdminPassword = { };
+          # The plaintext half of the pair whose pbkdf2 digest ./authelia.nix
+          # reads, declared on the side that needs the real value.
+          autheliaOidcMinifluxClientSecret = { };
+        };
+
+        # `adminCredentialsFile` is the module's *only* EnvironmentFile hook, so
+        # both secrets travel through it. Neither can go in `config` below, which
+        # the module renders into the unit's `Environment=` — the store and the
+        # journal, as ./shelfmark.nix notes. Left root-owned, unlike every
+        # sibling here: the unit runs with DynamicUser, so there is no account to
+        # chown to, and PID 1 reads EnvironmentFile before dropping privileges.
+        templates.minifluxEnvironment.content = ''
+          ADMIN_USERNAME=tguimbert
+          ADMIN_PASSWORD=${config.sops.placeholder.minifluxAdminPassword}
+          OAUTH2_CLIENT_SECRET=${config.sops.placeholder.autheliaOidcMinifluxClientSecret}
+        '';
+      };
+
+      services = {
+        miniflux = {
+          # `createDatabaseLocally` defaults on, declaring the role and the
+          # database in ./postgresql.nix's cluster and ordering this after it.
+          enable = true;
+          adminCredentialsFile = config.sops.templates.minifluxEnvironment.path;
+
+          # Freeform `str`/`int` only: the module coerces a bool for
+          # CREATE_ADMIN, RUN_MIGRATIONS and WATCHDOG alone, so `false` anywhere
+          # else would be `toString false`, the empty string.
+          config = {
+            BASE_URL = baseUrl;
+            LISTEN_ADDR = "127.0.0.1:${toString port}";
+
+            OAUTH2_PROVIDER = "oidc";
+            OAUTH2_CLIENT_ID = "miniflux";
+            OAUTH2_OIDC_PROVIDER_NAME = "Authelia";
+            # The *issuer*, not the discovery document ./mealie.nix points at:
+            # go-oidc appends /.well-known/openid-configuration itself, then
+            # compares the issuer it gets back byte for byte. So that suffix and
+            # a trailing slash both break it — at startup, not at first login.
+            OAUTH2_OIDC_DISCOVERY_ENDPOINT = "https://auth.${constants.domain}";
+            # Miniflux serves GET /oauth2/{provider}/callback, and ./authelia.nix
+            # registers this URL byte for byte; a mismatch is reported only as an
+            # invalid redirect.
+            OAUTH2_REDIRECT_URL = "${baseUrl}/oauth2/oidc/callback";
+            # Its default, and ./paperless.nix's stance: the Authelia identity is
+            # *linked* onto an existing account, so nobody self-provisions one.
+            OAUTH2_USER_CREATION = 0;
+
+            # DISABLE_LOCAL_AUTH is left off for ./paperless.nix's and
+            # ./mealie.nix's reason: the password login is the way in when
+            # Authelia is the thing that is down.
+          };
+        };
+
+        # `mkRouter`, not `mkAutheliaRouter`, joining ./jellyfin.nix and the
+        # rest: the phone clients speak Miniflux's own API — or the Fever and
+        # Google Reader ones it also serves — and cannot complete a browser SSO
+        # round trip.
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "miniflux";
+          inherit port;
+        };
+      };
+    };
+}

--- a/modules/server/paperless.nix
+++ b/modules/server/paperless.nix
@@ -13,12 +13,18 @@
       lib,
       mkHeartbeat,
       mkRouter,
+      requirePostgresql,
       ...
     }:
     let
       inherit (config.services.paperless) consumptionDir dataDir;
     in
     {
+      # The cluster below is preserved by ./postgresql.nix, not here; taking its
+      # argument is what makes a host importing this aspect without that one fail
+      # to evaluate.
+      assertions = [ (requirePostgresql "paperless") ];
+
       # `dataDir` is preserved at 0750 below, and 0777 on the consume directory
       # buys nothing without search permission on the way to it — so the one
       # writer gets the group rather than the archive getting 0755. Without this
@@ -166,24 +172,17 @@
       # unit; the cost is that `paperless` without `gatus` fails to evaluate.
       systemd.services.paperless-exporter.serviceConfig = mkHeartbeat "paperless-exporter";
 
-      # No uid pinning, unlike every sibling aspect: nixpkgs allocates both of
-      # these statically (`ids.uids.paperless = 315`, `postgres = 71`), so they
-      # already survive a rebuild.
+      # No uid pinning, unlike every sibling aspect: nixpkgs allocates paperless
+      # statically (`ids.uids.paperless = 315`), so it already survives a
+      # rebuild. PostgreSQL is preserved by ./postgresql.nix, which owns the
+      # cluster this shares with ./miniflux.nix. Redis is absent on purpose: a
+      # celery broker, the same reasoning as ./gatus.nix's unpreserved sqlite
+      # store.
       preservation.preserveAt."/persistent".directories = [
         {
           directory = dataDir;
           user = "paperless";
           group = "paperless";
-          mode = "0750";
-        }
-        {
-          # The parent, not `services.postgresql.dataDir`, which carries the
-          # major version — pinning that would land the next cluster on the tmpfs
-          # root. Redis is absent on purpose: a celery broker, the same reasoning
-          # as ./gatus.nix's unpreserved sqlite store.
-          directory = "/var/lib/postgresql";
-          user = "postgres";
-          group = "postgres";
           mode = "0750";
         }
       ];

--- a/modules/server/postgresql.nix
+++ b/modules/server/postgresql.nix
@@ -1,0 +1,44 @@
+{ ... }:
+{
+  # The PostgreSQL cluster, owned by one aspect rather than by whichever service
+  # asked for it first. ./paperless.nix turns it on through `database.createLocally`
+  # and ./miniflux.nix has no other engine to choose from, so left where it was the
+  # preserved data directory would belong to one of them and the other would depend
+  # on that aspect being imported without saying so — the trap ./mealie.nix
+  # documents from the other side.
+  nixos.modules.postgresql =
+    { config, lib, ... }:
+    let
+      # The *parent*, not `services.postgresql.dataDir`, which carries the major
+      # version: pinning that would land the next cluster on the tmpfs root.
+      dataDir = "/var/lib/postgresql";
+    in
+    {
+      services.postgresql.enable = true;
+
+      # Called by the aspects that keep their state in here, in ./gatus.nix's
+      # `mkHeartbeat` idiom: taking the argument is what makes a host importing
+      # one of them without this one fail to evaluate. The assertion covers the
+      # other half — this aspect imported, the preservation entry edited away.
+      _module.args.requirePostgresql = service: {
+        assertion = lib.any (
+          entry: entry.directory == dataDir
+        ) config.preservation.preserveAt."/persistent".directories;
+        message = ''
+          ${service} keeps its state in PostgreSQL, but ${dataDir} is not preserved:
+          the cluster would live on the tmpfs root and be empty after every reboot.
+        '';
+      };
+
+      # No uid pinning, unlike most sibling aspects: nixpkgs allocates postgres
+      # statically (`ids.uids.postgres = 71`), so it survives a rebuild already.
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = dataDir;
+          user = "postgres";
+          group = "postgres";
+          mode = "0750";
+        }
+      ];
+    };
+}

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -41,6 +41,9 @@ autheliaOidcMealieClientSecretDigest: ENC[AES256_GCM,data:/xcFwT7ehmkcxHS0ANyx6F
 radicaleLdapPassword: ENC[AES256_GCM,data:NQYWqI9Urg2/PBx9qVryCa4eWOO5y7fcx9eTxOAntWM=,iv:jLf/vf805kI4d7mTQly0Cu4vrnLhifvgTVT8AT/BpMI=,tag:pBrH+68l8iW+kDYq65T6Gw==,type:str]
 couchdbAdminPassword: ENC[AES256_GCM,data:S51TlIN26Wf3vruvuiklppFz0QUTKB3QjdhrPtoGJ3IJNGFZQhEsYjjHqkgPihcSJg6CfqTa4yL+/pQitqLfiA==,iv:9gSmPrHHuSQ1NFvEosaR+7s15zVMXd1X2An5+v30bwQ=,tag:+RdBELba3oqHCPpzFGp3Aw==,type:str]
 upsMonitorPassword: ENC[AES256_GCM,data:A0wAwvAr0JmI3zIUL21awZQaaQ8mNcXan63g4+vVvwc=,iv:ixyYOS39plBeMkuWYDgMxCjyXEBc1e+jKH4b58mkA8Q=,tag:1znEZOL7wuS20UDsp4Ev3w==,type:str]
+autheliaOidcMinifluxClientSecret: ENC[AES256_GCM,data:J6Jo7HY98WcCQEa20BMgdw2xuUMWeUB45urZrldU/I/z3F9dw3zzNNrmU8bRqNl2toy30/KBJbs6uo3RQ7RktJT2JIDIgHxh,iv:3sEaVi35Eop6V/1IP8U3Vftib2PleP+brMRYf09laaE=,tag:QpqkwzxGV9XFjdeGpshDTw==,type:str]
+autheliaOidcMinifluxClientSecretDigest: ENC[AES256_GCM,data:NxEFI96wjUv/xq9B62WrfE9eUL/C6prv15DbIIubsg+5ieDmJGQKXvQfmznVdCHKKC+jhMylN+pdnmxAFkzrW4Cr7/G6Ug+gsWGwxd6EvI8urytj2ekDRTbgxOiW2JMvUb2hnM5mohF6a0zuvU1Xgz3N45mxDiVBkC6nj24WjD7jj7U=,iv:AYqhncHZ12gn4qCGo1+YfW1Uzn7UQhKOl/yj3lES5FY=,tag:1UNRa3uxpqwa7o2/gi3NOg==,type:str]
+minifluxAdminPassword: ENC[AES256_GCM,data:HQxvY07liT3+xQFElB783C5EGnlaWH4RykB0aXvc+rw=,iv:uRMfXaS3AzYA4CBdz9vhALRsN+eVurBueN8Vev12vo4=,tag:kN6afPeTWUSj1JHvPhQNlA==,type:str]
 sops:
     age:
         - enc: |
@@ -52,8 +55,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-09T13:56:01Z"
-    mac: ENC[AES256_GCM,data:Q7cqqSq3vMd1uFbzdplHRhKgD4rSK0OMm0ra8ogA9Roe/Y+GKSFVAr9+jzI1fyjKfX3Lmk+96fXaveDAdj/8FV/zlvc7j1LwBuHYWkBaetQMnM1IjhKORDFTb8Z5qslI2XmSgrdR4NoMuimtY2rzo0yROnL+skCTg5442qRroB4=,iv:TlydWqhgfXQ8udPfEaujfRGZH0O9r9nRwUCx7wcDHuE=,tag:YOWOp1cDAKPJjFlW95iLhg==,type:str]
+    lastmodified: "2026-08-16T11:13:10Z"
+    mac: ENC[AES256_GCM,data:AWW5Nrp1r0ORXG+BXV7s3WQDvc13U6IakYRcqK7IboTnFkkFm1QhyZmlaR4lhgCnDrrBTTwyYEbZofVEofID914vow2idtj0ke51DN3pDmtb1XgAaECYIjNdoVrEMM0BJMgm91G0QUztqGQvcc67JtEFpOGyeyVOWDbt9Z0N1pw=,iv:hFJMt7APONysMjvNtEvwSwvJYYzSK1h116o7ZKdnCGg=,tag:BRIOAsgp8ZX3jPYHHqOXMQ==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
RSS and Atom only: Reddit publishes a feed per subreddit, user and
multireddit, as do YouTube channels, so no bridge is deployed to
manufacture feeds for sites that publish none.

The route is mkRouter rather than mkAutheliaRouter — the phone clients
speak Miniflux's own API, or the Fever and Google Reader ones it also
serves — so it authenticates against Authelia over OIDC itself, with the
identity linked onto the sops-seeded local admin rather than
self-provisioned, and the password login left enabled as the way in when
Authelia is the thing that is down.

Miniflux has no sqlite mode and nothing on disk, which forced the
PostgreSQL cluster out of paperless.nix and into an aspect of its own:
`postgresql` now owns /var/lib/postgresql and publishes
`requirePostgresql`, so a host importing paperless or miniflux without it
fails to evaluate instead of putting the database on the tmpfs root.
Gatus polls /healthcheck — the one unauthenticated health path that
touches the database — and backup.nix stages the first pg_dump here.
