### PR TITLE
feat(srv-01): add Readeck for bookmarks and saved articles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,11 +98,12 @@ Three ways in, because apps fall into three groups:
   `modules/server/shelfmark.nix` when Calibre-web was removed.
 - **OIDC** — Authelia is also the OIDC provider (`identity_providers.oidc`), for apps that
   authenticate their own users. Clients are declared in that same file (Immich, Grimmory,
-  Paperless and Mealie), with the client secret's pbkdf2 digest pulled from sops via
-  `{{ secret "…" }}` rather than committed in cleartext. Discovery lives at
+  Paperless, Mealie, Miniflux and Readeck), with the client secret's pbkdf2 digest pulled from sops
+  via `{{ secret "…" }}` rather than committed in cleartext. Discovery lives at
   `https://auth.<domain>/.well-known/openid-configuration`.
-  **The four clients differ from each other in ways that all fail misleadingly**, so none of them
-  is a template for the next:
+  **The clients differ from each other in ways that all fail misleadingly**, so none of them
+  is a template for the next — Miniflux's four differences are in "News on srv-01" and Readeck's
+  in "Read-later on srv-01"; the ones the first four disagree on are:
   - *Where the claims come from.* Immich and Paperless read **userinfo**; **Grimmory reads the ID
     token**, where Authelia puts only a standard subset. So Grimmory — and only Grimmory — needs a
     `claims_policies` entry naming `preferred_username`, `email`, `name` and `groups`; without it
@@ -122,6 +123,11 @@ Three ways in, because apps fall into three groups:
   `PAPERLESS_SOCIALACCOUNT_PROVIDERS` (`/accounts/oidc/<provider_id>/login/callback/`), and
   Mealie's from its own `BASE_URL` plus `/login`, so in both cases two files have to agree byte for
   byte — a mismatch is reported only as an invalid redirect.
+  One thing is *not* per-client: `authorization_policy`. Five clients use the built-in
+  `two_factor`, which lets in every Authelia user; **Readeck is the only one on a custom
+  `identity_providers.oidc.authorization_policies` entry**, because it is the only app here whose
+  own group mapping cannot refuse anyone. Reach for that mechanism — not `access_control`, which
+  an OIDC route never passes through — whenever a client needs gating on a group.
 - **LDAP** (`modules/server/lldap.nix`) — for apps that speak neither. Kept **deliberately**: the
   Jellyfin OIDC plugin (`9p4/jellyfin-plugin-sso`) was archived upstream in May 2026 with no
   successor fork, and never completed the flow outside a browser anyway, so LDAP is the only
@@ -767,6 +773,82 @@ the Authelia identity is *linked* onto the existing account from the settings pa
 self-provisioned, and the password login is the way in when Authelia is the thing that is down.
 Bring-up is in README.md, "Bringing up Miniflux".
 
+### Read-later on srv-01
+
+`readeck` (`modules/server/readeck.nix`) — bookmarks and saved articles: extraction into a
+readable copy, highlights, labels, collections, EPUB export and an OPDS catalogue. The natural
+other end of `miniflux`, which ships a Readeck integration, so *Save entry* in the reader files
+into the library. Everything is in one sqlite database plus a `bookmarks/` tree of extracted
+archives, so it falls into `backup.nix`'s existing online-backup loop beside every other sqlite
+service here.
+
+The route is `mkRouter`, not `mkAutheliaRouter`, joining Jellyfin, Jellyseerr, Grimmory,
+Paperless, Mealie, Radicale, CouchDB and Miniflux: the browser authenticates over OIDC, and the
+browser extension, the OPDS readers and the API all carry **Readeck's own Bearer tokens** — which
+the forward-auth middleware would reject outright, since `authelia.nix` gives it a
+`HeaderAuthorization` strategy that reads the very same header.
+
+**It is the only aspect here whose package comes from `unstable`.** 26.05 carries **0.22.3**,
+whose sole delegated auth is `auth.forwarded` — proxy headers, which upstream **removed** in 0.23
+and replaced with `auth.oidc`. Writing against the stable version would mean building on a
+mechanism that no longer exists. Only the *package* is overlaid (`modules/nixpkgs.nix`); the
+NixOS module stays 26.05's, and the one hunk the two module versions differ in is neutralised by
+the secret key below. **The override announces its own expiry**: it is wrapped in a `warnIf` that
+fires once stable carries ≥ 0.23, so the weekly lockfile PR's CI run is what tells you to drop it
+— a warning and not an assertion, because failing eval would block the very PR carrying the fix.
+
+Five things fail misleadingly:
+
+- **`READECK_SECRET_KEY` is not optional, and omitting it fails differently on each module
+  version.** Readeck derives its session, token and TOTP keys from `main.secret_key`, and when
+  that is empty it *generates* one and **writes it back into the config file**. Under the 26.05
+  module that file is a store path, so the write fails and the service never starts. Under the
+  unstable module — which copies the config into the state directory first — it would instead mint
+  a **new key on every start**, silently invalidating every API token and session on each nightly
+  restart, with nothing in the journal to say so. Supplying it from sops is what stops readeck
+  writing at all, and is what makes the mixed module/package pairing above safe.
+- **The client secret gets in through an index, not a key.** `settings` renders into the store, so
+  it cannot hold the secret; readeck merges `READECK_AUTH_OIDC_PROVIDERS_<n>_<PROP>` into the
+  provider declared at **index `<n>`** of the config file's list rather than appending a new one,
+  so `…_0_CLIENT_SECRET` completes the entry declared in Nix. Get the index wrong and you get a
+  second, half-configured provider rather than an error.
+- **Readeck's `groups` map cannot refuse anyone.** It maps an OIDC group onto one of readeck's own
+  (`user`, `staff`, `admin`) and falls through to `user` when nothing matches — so it is a *role*
+  map, and the access gate has to be Authelia's. That is the custom
+  `identity_providers.oidc.authorization_policies.readeck` entry, with `default_policy = "deny"`;
+  the `access_control` rules cannot do it, because a route with no forward-auth middleware never
+  reaches them. Getting this wrong looks like nothing at all — every Authelia user simply has an
+  account.
+- **The group map is re-applied on every login, and order decides ties.** First match wins, so
+  `readeck-admins` must precede `readeck-users` or someone in both is mapped to `user`. And
+  because it is re-applied rather than applied once, removing the admins entry — or dropping
+  someone from that LLDAP group — *demotes* the existing account rather than leaving it be. The
+  same re-application is what makes the local account created at onboarding pick up its role.
+- **A wrong issuer fails at the first login, not at startup** — the opposite of Miniflux, whose
+  `OAUTH2_OIDC_DISCOVERY_ENDPOINT` is resolved eagerly. Readeck loads the provider lazily, so a
+  bad `url` leaves a clean journal until someone actually tries to sign in. It is the issuer, with
+  neither the `/.well-known/openid-configuration` suffix nor a trailing slash: go-oidc appends the
+  suffix and compares the issuer it gets back byte for byte.
+
+`server.base_url` is required rather than cosmetic: readeck builds its OIDC redirect URI as
+`<base_url>/login/oidc`, and without it that comes from the proxy headers — so the URI
+`authelia.nix` registers could not be guaranteed to match. The uid is pinned (362) for `lldap.nix`'s
+reason, and `DynamicUser` forced off, since the module defaults it on and a uid allocated per boot
+cannot own preserved state.
+
+**Readeck auto-links an OIDC identity onto an existing local account** by matching username or
+email — which Paperless deliberately does not do. That is what makes the bring-up work: create the
+first account through readeck's onboarding screen, using the same username and email as the
+Authelia identity, and the first OIDC login adopts it rather than making a second. Doing it that
+way is also what leaves a **local password** on the account, which an OIDC-provisioned one never
+has (readeck gives those a random 64-character password nobody knows) — so it is the way in when
+Authelia is the thing that is down, the argument `paperless.nix` and `miniflux.nix` both make.
+
+The Gatus check is weaker than its siblings and deliberately so: `/api/info` is the one route
+readeck mounts outside its authenticated router, and it renders from build info alone, so it would
+stay green with the database gone. There is no unauthenticated path that touches sqlite.
+Bring-up is in README.md, "Bringing up Readeck".
+
 ### Formatting and Linting
 
 ```bash
@@ -847,7 +929,7 @@ Each host is a thin import list in `modules/machines/<hostname>.nix` — it sets
 **Current hosts**:
 - `leshen`: Desktop system with niri + noctalia, games, podman (`displaysLeshen` for its dual monitors)
 - `griffin`: Lenovo ThinkPad T490 laptop with niri + noctalia, games, podman (`laptop` for lid handling)
-- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, Miniflux, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; it is a NUT secondary of the UPS on the NAS — see "Power on srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", CouchDB in "Obsidian sync on srv-01", and Miniflux plus the shared PostgreSQL cluster in "News on srv-01"
+- `srv-01`: Headless bare-metal server with Traefik, LLDAP, Authelia (forward-auth + OIDC provider), Homepage, Jellyfin + the *arr + SABnzbd + Grimmory + Shelfmark over one NFS library from the NAS, Paperless-ngx fed by the multifunction printer's scanner, Mealie, Radicale, CouchDB, Miniflux, Readeck, and a Home Assistant OS libvirt guest bridged onto the LAN via `br0`; LUKS unlocked from the TPM (PCR 7). Backups are a TrueNAS pull, not a push — see "Backing up srv-01"; monitoring is split with the NAS — see "Monitoring srv-01"; it is a NUT secondary of the UPS on the NAS — see "Power on srv-01"; the media stack is in "Media on srv-01", the ebook one in "Books on srv-01" (which is also the only container on this host), Paperless plus the scanner in "Documents on srv-01", Mealie in "Recipes on srv-01", Radicale in "Calendars and contacts on srv-01", CouchDB in "Obsidian sync on srv-01", Miniflux plus the shared PostgreSQL cluster in "News on srv-01", and Readeck in "Read-later on srv-01"
 
 ### Module Organization
 
@@ -855,7 +937,7 @@ One feature = one capability file holding its NixOS **and** home-manager config 
 - `nixos.modules.base` — every host (boot, locale, nix settings, disko, user account + nushell login shell, sshd, avahi, fwupd/smartd/btrfs-scrub, cli tools, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager + CIFS, tailscale, printing client, GUI home)
 - `nixos.modules.server` — srv-01 baseline (`modules/server/`); deliberately thin — only the sops file, the headless service disables and static networking
-- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `postgresql`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`, `miniflux`)
+- Named opt-in aspects imported only by hosts that want them: `secureBoot` (lanzaboote; every host with a bootloader), `autoUpgrade` (pull-based nightly updates; srv-01 only), `games`, `podman`, `displaysLeshen`, `laptop`, `docker` (no host currently imports it), and the srv-01 services (`traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `postgresql`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`, `miniflux`, `readeck`)
 
 **Cross-aspect collectors.** A few things are contributed *by* a feature but assembled by
 another. Rather than a central list that drifts, the assembling aspect declares a collector and
@@ -1033,7 +1115,7 @@ Scaffolding files live **flat in `modules/`** (`nixos.nix`, `home-manager.nix`, 
 - `nixos.modules.base` — every host (nix settings, locale, boot, disko, user, sshd/avahi/fwupd/smartd, preservation, sops)
 - `nixos.modules.desktop` — desktop hosts (niri, noctalia, greeter, appearance, firefox, audio, NetworkManager, tailscale); also pulls `home.gui`
 - `nixos.modules.server` — srv-01 baseline
-- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `postgresql`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`, `miniflux`
+- Named opt-in aspects: `secureBoot`, `autoUpgrade`, `games`, `podman`, `displaysLeshen`, `laptop`, `docker`, `traefik`, `authelia`, `lldap`, `homepage`, `backup`, `printScan`, `homeAssistant`, `gatus`, `beszel`, `ups`, `postgresql`, `mediaLibrary`, `jellyfin`, `servarr`, `sabnzbd`, `bazarr`, `recyclarr`, `jellyseerr`, `grimmory`, `shelfmark`, `paperless`, `mealie`, `radicale`, `couchdb`, `miniflux`, `readeck`
 
 **Deliberate divergences from mightyiam/infra**: no `flake-file` (inputs stay hand-written in `flake.nix`); inputs stay real flakes (use `inputs.home-manager.nixosModules.home-manager`, not `flake = false`); single user `tguimbert` hardcoded (no multi-user `users` option machinery). Hardware detection uses nixpkgs' `hardware.facter` (report at `modules/_hosts/<host>/facter.json`, must be git-tracked); a slim `hardware.nix` per host keeps `facter.reportPath` + quirks facter can't detect.
 

--- a/README.md
+++ b/README.md
@@ -590,6 +590,48 @@ for a user or a multireddit, as do YouTube channels. A **403** from Reddit is it
 fetcher's user agent, not a misconfiguration — set a per-feed **User Agent** in the feed's
 settings.
 
+### Bringing up Readeck
+
+Readeck is the bookmark and read-later library — the other end of Miniflux. It authenticates over
+OIDC against Authelia, and access is gated on an **LLDAP group**, because Readeck's own group
+mapping only chooses a role and cannot refuse anyone. Neither the groups nor the first account can
+come from this repo, so the first run is a short bootstrap:
+
+1. **LLDAP** (`https://ldap.home.guimbert.fr`) — create two groups and add yourself to both:
+   - `readeck-users` — the gate. `modules/server/authelia.nix` refuses anyone outside it, through
+     a custom `authorization_policies.readeck` entry rather than an `access_control` rule; an OIDC
+     route carries no forward-auth middleware, so those rules never apply to it.
+   - `readeck-admins` — the role. `modules/server/readeck.nix` maps it onto Readeck's `admin`
+     group. **Not optional if you want to be an admin**: the map is re-applied on every login, so
+     an account outside this group is set back to `user` each time it signs in.
+2. `sops secrets/srv-01.yaml` and add three values:
+   - `readeckSecretKey` — 48 random bytes, base64: `openssl rand -base64 48`. Readeck derives its
+     session, token and TOTP keys from it. **Do not skip it and do not rotate it casually**: left
+     unset, Readeck tries to write a generated key into its config file, which is a store path, and
+     the service fails to start; changing it later invalidates every session and API token.
+   - `autheliaOidcReadeckClientSecret` and `autheliaOidcReadeckClientSecretDigest` — a pair from
+     `authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72`, exactly
+     as for Mealie and Miniflux: the plaintext goes into Readeck's environment file, the digest
+     into `modules/server/authelia.nix`.
+3. `just deploy srv-01`, then open `https://readeck.home.guimbert.fr`. With no users yet it
+   redirects to **`/onboarding`**, which creates the first account with a local password.
+   **Use the same username and email as your Authelia identity**, and keep that password in your
+   password manager.
+4. Sign out, then sign back in with **Sign in with Authelia**. Readeck matches on username or
+   email and **links** the OIDC identity onto the account from step 3 rather than creating a
+   second one — so you keep the local password, which is the way in when Authelia is the thing
+   that is down. Confirm the role stuck: an admin sees the *Administration* section.
+   A wrong issuer URL fails **here, at the first login**, not at startup — unlike Miniflux — so
+   check `ssh srv-01.local journalctl -u readeck` at this step rather than after the deploy.
+5. Wire up Miniflux: **Settings → Integrations → Readeck**, with
+   `https://readeck.home.guimbert.fr` and an API token minted in Readeck under **Profile → API
+   tokens**. *Save entry* on an article then files it into the library. The same token works for
+   the browser extension, and OPDS readers point at `/opds` — none of which would work behind the
+   Authelia middleware, which is why this route carries none.
+
+Revoking someone is removing them from `readeck-users`; their existing bookmarks stay, and the
+account is refused at the Authelia consent step on the next login.
+
 ### Bringing up the UPS client
 
 The UPS is on the TrueNAS's USB port and the NAS runs NUT's `upsd` as the primary;

--- a/flake.lock
+++ b/flake.lock
@@ -598,11 +598,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1786384358,
-        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {

--- a/modules/desktop/firefox.nix
+++ b/modules/desktop/firefox.nix
@@ -83,6 +83,7 @@
               # noctalia native-messaging host whose manifest is installed by the
               # `noctaliaFirefoxHost` activation script in modules/niri.nix.
               pywalfox
+              readeck
             ];
           };
         };

--- a/modules/machines/srv-01.nix
+++ b/modules/machines/srv-01.nix
@@ -32,6 +32,7 @@
         radicale
         couchdb
         miniflux
+        readeck
       ])
       ++ [
         ../_hosts/srv-01/hardware.nix

--- a/modules/nixpkgs.nix
+++ b/modules/nixpkgs.nix
@@ -22,6 +22,17 @@ let
         claude-code
         ;
 
+      # The one override here that is not a "newer is nicer" desktop package, and
+      # so the only one with an expiry: 26.05 carries 0.22.3, whose `auth.forwarded`
+      # upstream removed in 0.23 in favour of the `auth.oidc` ./server/readeck.nix
+      # configures. Only the package is overridden; that file explains why pairing
+      # it with 26.05's module is safe. A warning and not an assertion, because
+      # failing eval would block the very lockfile PR that carries the fix.
+      readeck =
+        prev.lib.warnIf (prev.lib.versionAtLeast prev.readeck.version "0.23")
+          "nixpkgs now carries readeck ${prev.readeck.version}; drop this override and modules/server/readeck.nix's note about it"
+          unstable.readeck;
+
       nushellPlugins.formats = unstable.nushellPlugins.formats;
 
       azure-cli = unstable.azure-cli.withExtensions [

--- a/modules/server/authelia.nix
+++ b/modules/server/authelia.nix
@@ -46,6 +46,7 @@
           autheliaOidcPaperlessClientSecretDigest = sopsConfig;
           autheliaOidcMealieClientSecretDigest = sopsConfig;
           autheliaOidcMinifluxClientSecretDigest = sopsConfig;
+          autheliaOidcReadeckClientSecretDigest = sopsConfig;
         };
       };
       services = {
@@ -317,7 +318,53 @@
                   # `token_endpoint_auth_method`: golang.org/x/oauth2
                   # auto-detects, trying basic — Authelia's default — first.
                 }
+                {
+                  client_id = "readeck";
+                  client_name = "Readeck";
+                  client_secret = "{{ secret \"${config.sops.secrets.autheliaOidcReadeckClientSecretDigest.path}\" }}";
+                  public = false;
+                  # The one client not on a built-in policy: readeck's own group
+                  # map assigns a role and cannot refuse anyone, so the gate has
+                  # to be the policy defined below.
+                  authorization_policy = "readeck";
+                  consent_mode = "pre-configured";
+                  pre_configured_consent_duration = "1 year";
+                  # Required rather than permitted: readeck sends a challenge
+                  # whenever discovery advertises the method, which Authelia does.
+                  require_pkce = true;
+                  pkce_challenge_method = "S256";
+                  response_types = [ "code" ];
+                  grant_types = [ "authorization_code" ];
+                  id_token_signed_response_alg = "RS256";
+                  # Built from ./readeck.nix's `server.base_url` plus the route
+                  # readeck mounts its callback on, so the two have to match.
+                  redirect_uris = [ "https://readeck.${constants.domain}/login/oidc" ];
+                  # Exactly what readeck hardcodes into its oauth2 config, so
+                  # `groups` cannot be trimmed even though it maps only a role.
+                  scopes = [
+                    "openid"
+                    "profile"
+                    "email"
+                    "groups"
+                  ];
+                  # No `claims_policy` and no `userinfo_signed_response_alg`,
+                  # both for Mealie's reasons above: readeck reads the ID token
+                  # first and falls back to userinfo.
+                }
               ];
+              # The gate for ./readeck.nix. `access_control` cannot do this job —
+              # an OIDC route carries no forward-auth middleware and so never
+              # reaches those rules — and `default_policy` is what makes it a gate
+              # rather than a preference.
+              authorization_policies.readeck = {
+                default_policy = "deny";
+                rules = [
+                  {
+                    policy = "two_factor";
+                    subject = [ "group:readeck-users" ];
+                  }
+                ];
+              };
               claims_policies.grimmory.id_token = [
                 "preferred_username"
                 "email"

--- a/modules/server/backup.nix
+++ b/modules/server/backup.nix
@@ -57,6 +57,9 @@
         # ordering rule — secondary indexes first — falls out of rsync's sorted
         # walk, since `.shards/` precedes `shards/`.
         "/var/lib/couchdb"
+        # `bookmarks/`, the extracted article archives — the half of
+        # ./readeck.nix nothing can re-fetch once the original page is gone.
+        "/var/lib/readeck"
       ];
       # Not here on purpose: sabnzbd, whose state is a re-downloadable queue, and
       # recyclarr, whose directory is a clone of the TRaSH guides plus a config
@@ -80,6 +83,9 @@
         "${config.services.seerr.configDir}/db/db.sqlite3"
         "/var/lib/shelfmark/users.db"
         "/var/lib/mealie/mealie.db"
+        # Bookmarks, labels and highlights; the archives they point at are in
+        # the rsync above.
+        "/var/lib/readeck/db.sqlite3"
       ];
 
       # Grimmory's library metadata, users and OIDC client. The only thing staged

--- a/modules/server/gatus.nix
+++ b/modules/server/gatus.nix
@@ -273,6 +273,16 @@
                 path = "/_up";
                 conditions = [ "[BODY].status == ok" ];
               })
+              # Exempt from the middleware for the same reason again. `/api/info`
+              # is the one route readeck mounts outside its authenticated router,
+              # but it renders from build info alone — so unlike miniflux's
+              # `/healthcheck` this stays green with the database gone. There is
+              # no unauthenticated path that touches sqlite.
+              (mkHttps {
+                name = "readeck";
+                path = "/api/info";
+                conditions = [ "len([BODY].version.release) > 0" ];
+              })
               (mkHttps { name = "immich"; })
               (mkHttps {
                 name = "garage";

--- a/modules/server/readeck.nix
+++ b/modules/server/readeck.nix
@@ -1,0 +1,154 @@
+{ ... }:
+{
+  # Bookmarks and read-later: article extraction, highlights, labels,
+  # collections, EPUB export and an OPDS catalogue. The ./miniflux.nix shape —
+  # an ordinary nixpkgs module, one unit, one sqlite file — rather than the
+  # ./grimmory.nix one, with a single exception: ../nixpkgs.nix takes the
+  # *package* from unstable, because 26.05 carries 0.22.3 and the OIDC support
+  # this file is written against arrived in 0.23.
+  # ../../CLAUDE.md, "Read-later on srv-01".
+  nixos.modules.readeck =
+    {
+      config,
+      constants,
+      lib,
+      mkRouter,
+      ...
+    }:
+    let
+      # Next after ./miniflux.nix's 8087, rather than readeck's own default 8000.
+      port = 8088;
+      baseUrl = "https://readeck.${constants.domain}";
+      stateDir = "/var/lib/readeck";
+    in
+    {
+      # nixpkgs runs readeck under DynamicUser (forced off below), so the uid is
+      # pinned for ./lldap.nix's reason: a uid allocated per boot cannot own
+      # preserved state. 361 is ./radicale.nix.
+      users = {
+        users.readeck = {
+          isSystemUser = true;
+          group = "readeck";
+          uid = 362;
+        };
+        groups.readeck.gid = 362;
+      };
+
+      homepageTiles.Services = [
+        {
+          Readeck = {
+            icon = "readeck.png";
+            href = baseUrl;
+            siteMonitor = baseUrl;
+            description = "Bookmarks and read-later";
+          };
+        }
+      ];
+
+      sops = {
+        secrets = {
+          readeckSecretKey = { };
+          # The plaintext half of the pair whose pbkdf2 digest ./authelia.nix
+          # reads, declared on the side that needs the real value.
+          autheliaOidcReadeckClientSecret = { };
+        };
+
+        # Root-owned, like ./miniflux.nix's: PID 1 reads `EnvironmentFile=`
+        # before dropping privileges. Neither value can go in `settings` below,
+        # which the module renders into the store.
+        #
+        # The secret key is not optional. Readeck derives its session, token and
+        # TOTP keys from it and, left empty, generates one and writes it back
+        # into the config file — which here is a store path. Supplying it is what
+        # stops readeck writing at all, and so what makes the unstable package on
+        # 26.05's module safe. `…_PROVIDERS_0_…` merges into the provider at
+        # index 0 below rather than appending a second one.
+        templates.readeckEnvironment.content = ''
+          READECK_SECRET_KEY=${config.sops.placeholder.readeckSecretKey}
+          READECK_AUTH_OIDC_PROVIDERS_0_CLIENT_SECRET=${config.sops.placeholder.autheliaOidcReadeckClientSecret}
+        '';
+      };
+
+      systemd.services.readeck.serviceConfig = {
+        # ./mealie.nix's reason: it would otherwise put the state below in
+        # /var/lib/private/readeck, owned by a uid allocated per boot.
+        DynamicUser = lib.mkForce false;
+        User = "readeck";
+        Group = "readeck";
+      };
+
+      services = {
+        readeck = {
+          enable = true;
+          environmentFile = config.sops.templates.readeckEnvironment.path;
+
+          settings = {
+            # Defaults to the relative "data" under the unit's WorkingDirectory,
+            # so stating it keeps the database and the `bookmarks/` archives in
+            # the one preserved directory. ./backup.nix stages both.
+            main.data_directory = stateDir;
+
+            server = {
+              host = "127.0.0.1";
+              inherit port;
+              # Required, not cosmetic: readeck builds its OIDC redirect URI as
+              # `<base_url>/login/oidc`, and without this it takes the base from
+              # the proxy headers — so the URI ./authelia.nix registers could not
+              # be guaranteed to match.
+              base_url = baseUrl;
+            };
+
+            auth.oidc.providers = [
+              {
+                name = "Authelia";
+                # The *issuer*, like ./miniflux.nix's, so neither the
+                # /.well-known/openid-configuration suffix nor a trailing slash.
+                # Unlike Miniflux it is resolved lazily, so a wrong value fails
+                # at the first login and leaves a clean journal until then.
+                url = "https://auth.${constants.domain}";
+                client_id = "readeck";
+                # client_secret is deliberately absent; see the sops template.
+
+                # Safe only because it is not the gate: ./authelia.nix refuses
+                # anyone outside `readeck-users` before the flow reaches here.
+                provisioning = true;
+
+                # A role map, not an access list — an identity matching nothing
+                # here still gets in, as `user`. First match wins, so the admins
+                # entry must come first; and it is re-applied on every login, so
+                # removing an entry demotes the accounts it covered.
+                groups = [
+                  [
+                    "readeck-admins"
+                    "admin"
+                  ]
+                  [
+                    "readeck-users"
+                    "user"
+                  ]
+                ];
+              }
+            ];
+          };
+        };
+
+        # `mkRouter`, not `mkAutheliaRouter`, joining ./jellyfin.nix and the rest:
+        # readeck authenticates its own clients, and the Bearer tokens its
+        # extension and OPDS readers carry would be rejected by the forward-auth
+        # middleware, whose `HeaderAuthorization` strategy reads that same header.
+        traefik.dynamicConfigOptions.http = mkRouter {
+          name = "readeck";
+          inherit port;
+        };
+      };
+
+      preservation.preserveAt."/persistent".directories = [
+        {
+          directory = stateDir;
+          user = "readeck";
+          group = "readeck";
+          mode = "0750";
+        }
+      ];
+    };
+}

--- a/secrets/srv-01.yaml
+++ b/secrets/srv-01.yaml
@@ -44,6 +44,9 @@ upsMonitorPassword: ENC[AES256_GCM,data:A0wAwvAr0JmI3zIUL21awZQaaQ8mNcXan63g4+vV
 autheliaOidcMinifluxClientSecret: ENC[AES256_GCM,data:J6Jo7HY98WcCQEa20BMgdw2xuUMWeUB45urZrldU/I/z3F9dw3zzNNrmU8bRqNl2toy30/KBJbs6uo3RQ7RktJT2JIDIgHxh,iv:3sEaVi35Eop6V/1IP8U3Vftib2PleP+brMRYf09laaE=,tag:QpqkwzxGV9XFjdeGpshDTw==,type:str]
 autheliaOidcMinifluxClientSecretDigest: ENC[AES256_GCM,data:NxEFI96wjUv/xq9B62WrfE9eUL/C6prv15DbIIubsg+5ieDmJGQKXvQfmznVdCHKKC+jhMylN+pdnmxAFkzrW4Cr7/G6Ug+gsWGwxd6EvI8urytj2ekDRTbgxOiW2JMvUb2hnM5mohF6a0zuvU1Xgz3N45mxDiVBkC6nj24WjD7jj7U=,iv:AYqhncHZ12gn4qCGo1+YfW1Uzn7UQhKOl/yj3lES5FY=,tag:1UNRa3uxpqwa7o2/gi3NOg==,type:str]
 minifluxAdminPassword: ENC[AES256_GCM,data:HQxvY07liT3+xQFElB783C5EGnlaWH4RykB0aXvc+rw=,iv:uRMfXaS3AzYA4CBdz9vhALRsN+eVurBueN8Vev12vo4=,tag:kN6afPeTWUSj1JHvPhQNlA==,type:str]
+autheliaOidcReadeckClientSecret: ENC[AES256_GCM,data:QdZkHXwy+uUW0GPyPHh+0hTt42UrQe+zqZPwnG8xSPTyjJMsZadsvTrir7EHhJfZbRPilfUXJ48s/L1KN88zbnywH7E7zn+D,iv:uc0mawS9u8UB6ImntqcBoFpjtenLqyFtz1bQOsCq+4M=,tag:lChCh4/6nKZ+np23TWGZtQ==,type:str]
+autheliaOidcReadeckClientSecretDigest: ENC[AES256_GCM,data:Qs7+75pUowjWEgGlLfMBlVVYCVtVGYnQJ+o5SoQneQqZ92aYUGrjm4Y2PZJGrF+9UiR6rVcXCclhhXtPH+XO1MuF4vGuXFPXndEdcal1VpFerwy/cA5mDB9mQLjrayuQgb35MaSzyyypGjh1f4aIqh4F+6AwP/auluuG3OcHB6SZSiY=,iv:fBdMfH6iVi4SqeadN92NSdhL6nHqiuA2WpJlP8mNu+E=,tag:MSGkN7chIz7lXelRc6n+1w==,type:str]
+readeckSecretKey: ENC[AES256_GCM,data:MTuTaI+7lMsbfhtQX2OYv3R2aPeYTmB3dCIAX2YLXNBGwFXTIfZEUXqfLo9/a1ArcrfMIlRbxu5D3qPoGpB0Ag==,iv:WZgrFRPNgEes/x6V4V2sZOQ7/DVjJ+N9yfnaX3d15AQ=,tag:VF841pZUEN+hOHnbCB73+A==,type:str]
 sops:
     age:
         - enc: |
@@ -55,8 +58,8 @@ sops:
             NgeHW4KrE8F0sAPRrK14vaSHF6SY7Lk1/UhM7SiXmGr80xqqPktGjg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fw5kc4cggy0al3j6l85k8sk3r8xxfz4tgwt58w6yfx4g47w674msra78sv
-    lastmodified: "2026-08-16T11:13:10Z"
-    mac: ENC[AES256_GCM,data:AWW5Nrp1r0ORXG+BXV7s3WQDvc13U6IakYRcqK7IboTnFkkFm1QhyZmlaR4lhgCnDrrBTTwyYEbZofVEofID914vow2idtj0ke51DN3pDmtb1XgAaECYIjNdoVrEMM0BJMgm91G0QUztqGQvcc67JtEFpOGyeyVOWDbt9Z0N1pw=,iv:hFJMt7APONysMjvNtEvwSwvJYYzSK1h116o7ZKdnCGg=,tag:BRIOAsgp8ZX3jPYHHqOXMQ==,type:str]
+    lastmodified: "2026-08-16T18:56:28Z"
+    mac: ENC[AES256_GCM,data:HRUf26SUK8BWxZyUeghwc6wXCwe1f2TK8SVPn7gnM9WD+VVNRs5yoQ2vRdzpawJeAp4hEL84QhrJ4Mj5TyC24xT5Kyp418O7bGqsXP0nCWyBOZj79sKLHOZcfM/Mhl48Brwsk+v/PCDtkII+3cv7QoHt5hnWUO0jB+ZltehLfdE=,iv:lXrLasK/MjxDqMDdkRqv751dHAa4n9JEsDqnPSME/f8=,tag:SPRZG4vp4NWiPPJqHY5wdg==,type:str]
     pgp:
         - created_at: "2026-01-22T16:57:34Z"
           enc: |-


### PR DESCRIPTION
Readeck is the read-later half of the feed reader: article extraction,
highlights, labels, collections, EPUB export and an OPDS catalogue, in one
sqlite database plus a `bookmarks/` tree of archives. Miniflux ships a Readeck
integration, so *Save entry* files straight into the library.

The package comes from unstable, uniquely among the srv-01 aspects. 26.05
carries 0.22.3, whose only delegated auth is `auth.forwarded` — removed
upstream in 0.23 and replaced with `auth.oidc`. Only the package is overridden;
26.05's module is safe against it because READECK_SECRET_KEY is supplied from
sops, which stops readeck writing a generated key back into its config. The
override is wrapped in a `warnIf` that fires once stable catches up.

Access is gated on the LLDAP group `readeck-users` through a custom
`identity_providers.oidc.authorization_policies` entry — the first on this
host. `access_control` cannot do it, since an OIDC route carries no
forward-auth middleware; and readeck's own `groups` setting only maps a role,
falling through to `user` for an identity it does not recognise.

The route is `mkRouter`: readeck authenticates its own clients, and the Bearer
tokens its extension and OPDS readers carry would be rejected by the
forward-auth middleware's `HeaderAuthorization` strategy.

Bring-up is in README.md; `readeckSecretKey` is still to be added to
secrets/srv-01.yaml before the closure will build.
