### PR TITLE
fix(desktop): keep the Electron apps on the GNOME keyring under niri

### DIFF
--- a/modules/gui-apps.nix
+++ b/modules/gui-apps.nix
@@ -2,15 +2,41 @@
 {
   homeManager.modules.gui =
     { lib, pkgs, ... }:
+    let
+      # Chromium picks its OSCrypt backend by sniffing XDG_CURRENT_DESKTOP, and knows
+      # only GNOME, KDE and a handful of other names — under `niri` it silently falls
+      # back to the plaintext store, abandoning the login keyring keyring.nix unlocks.
+      # So every Electron app here stopped using it the day GNOME was dropped. Only
+      # Signal notices, and misleadingly: it records the backend it encrypted with, and
+      # afterwards opens db.sqlite with a key derived from the plaintext store, which
+      # SQLCipher reports as `SQLITE_NOTADB` — a decryption failure that reads as a
+      # corrupt database. Obsidian and Vesktop just mint a new key and lose whatever the
+      # old one protected.
+      #
+      # Wrapped rather than `.override { commandLineArgs = …; }`, the argument that
+      # exists for this: nixpkgs deprecates it, and signal-desktop builds from source,
+      # so overriding would blow the binary cache for one flag.
+      withLibsecret =
+        pkg:
+        pkgs.symlinkJoin {
+          name = "${lib.getName pkg}-libsecret";
+          paths = [ pkg ];
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/${baseNameOf (lib.getExe pkg)} \
+              --add-flags --password-store=gnome-libsecret
+          '';
+        };
+    in
     {
       home.packages = with pkgs; [
         vlc
         # `jellyfin-media-player` is the same derivation under the pre-2.0 name.
         jellyfin-desktop
         remmina
-        obsidian
+        (withLibsecret obsidian)
         mullvad-browser
-        signal-desktop
+        (withLibsecret signal-desktop)
         sone
 
         # Fallbacks for the GNOME panels/apps this desktop no longer ships;
@@ -34,7 +60,13 @@
       # module renders them as store symlinks under ~/.config/vesktop, and Vesktop
       # silently falls back to defaults rather than read a symlinked settings file
       # (Vencord/Vesktop#1136). So the config stays mutable and is preserved below.
-      programs.vesktop.enable = true;
+      programs.vesktop = {
+        enable = true;
+        # An overridable function rather than a plain derivation: the module installs
+        # `cfg.package.override { withSystemVencord = …; }`, and a symlinkJoin has no
+        # `.override`, so withLibsecret has to be re-applied on the far side of it.
+        package = lib.makeOverridable (args: withLibsecret (pkgs.vesktop.override args)) { };
+      };
 
       # Image viewer, in place of loupe.
       programs.swayimg.enable = true;


### PR DESCRIPTION
Signal refuses to start, with a dialog naming the OS encryption keyring and
suggesting --password-store="gnome-libsecret". The keyring is not the problem:
login.keyring is preserved and unlocked, org.freedesktop.secrets is served, and
the "Chromium Safe Storage" item for Signal is still there, untouched since the
minute its config.json was written.

Chromium picks its OSCrypt backend by sniffing XDG_CURRENT_DESKTOP, and
recognises only GNOME, KDE and a handful of other names — anything else falls
back to the plaintext store. So 4314764, which dropped GNOME for niri, quietly
took every Electron app here off the keyring on that date.

Only Signal notices, and misleadingly. It records the backend it encrypted with,
and afterwards opens db.sqlite with a key derived from the plaintext store,
which SQLCipher reports as SQLITE_NOTADB — a decryption failure that reads as a
corrupt database, next to a dialog offering to delete the data. Obsidian and
Vesktop just mint a new key and lose whatever the old one protected, so they get
the same treatment; expect a one-time re-login in both. Signal itself needs
none: the existing key and database open as they are.

Pinning the backend per app rather than appending GNOME to XDG_CURRENT_DESKTOP,
which would fix all three at once but make every other GTK program on the
session believe it runs under GNOME. Wrapped rather than
.override { commandLineArgs = …; }, the argument that exists for this: nixpkgs
deprecates it, and signal-desktop builds from source.

Vesktop takes an overridable function rather than a derivation, since the
home-manager module installs cfg.package.override { withSystemVencord = …; } and
a symlinkJoin has no .override.
